### PR TITLE
Remove django-nose

### DIFF
--- a/aiarena/settings.py
+++ b/aiarena/settings.py
@@ -59,15 +59,9 @@ DATABASES = {
     }
 }
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-NOSE_ARGS = [
-    '--with-coverage',
-    '--cover-package=aiarena'
-]
 # Application definition
 
 INSTALLED_APPS = [
-    'django_nose',
     'registration',
     'grappelli.dashboard',
     'grappelli',
@@ -393,7 +387,6 @@ if ENVIRONMENT_TYPE != EnvironmentType.DEVELOPMENT:
     MIDDLEWARE.remove('debug_toolbar.middleware.DebugToolbarMiddleware')
 
     INSTALLED_APPS.remove('sslserver')
-    INSTALLED_APPS.remove('django_nose')
 
 # load this after the env file so if the ELO_K value was overridden, it will be applied properly
 ELO = Elo(ELO_K)

--- a/pip/requirements.DEVELOPMENT.txt
+++ b/pip/requirements.DEVELOPMENT.txt
@@ -2,5 +2,4 @@ Werkzeug==1.0.1
 django-constance[database]==2.7.0
 django-sslserver
 django-debug-toolbar
-django-nose
 coverage


### PR DESCRIPTION
Since we are not using SonarQube anymore, we can move back to the original tests runner, which allows debugging in tests