### PR TITLE
Add trend indicators to main ranking page

### DIFF
--- a/aiarena/core/models/bot.py
+++ b/aiarena/core/models/bot.py
@@ -86,7 +86,7 @@ class Bot(models.Model, LockableModelMixin):
         from .relative_result import RelativeResult
         return (RelativeResult.objects
             .filter(me__bot=self, match__requested_by__isnull=True)
-            .order_by('-created')[:30]
+            .order_by('-created')[:config.ELO_TREND_N_MATCHES]
             .aggregate(Sum('elo_change'))['elo_change__sum'])
 
     @property

--- a/aiarena/core/models/bot.py
+++ b/aiarena/core/models/bot.py
@@ -85,7 +85,7 @@ class Bot(models.Model, LockableModelMixin):
     def current_elo_trend(self):
         from .relative_result import RelativeResult
         return (RelativeResult.objects
-            .filter(me__bot=self)
+            .filter(me__bot=self, match__requested_by__isnull=True)
             .order_by('-created')[:30]
             .aggregate(Sum('elo_change'))['elo_change__sum'])
 

--- a/aiarena/frontend/templates/index.html
+++ b/aiarena/frontend/templates/index.html
@@ -65,8 +65,8 @@
                             {{ participant.elo }}
                             {% with trend=participant.bot.current_elo_trend %}
                                 <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">
-                                    {% if trend > 0 %} trending_up
-                                    {% elif trend < 0 %} trending_down
+                                    {% if trend > 10 %} trending_up
+                                    {% elif trend < -10 %} trending_down
                                     {% else %} fast_rewind
                                     {% endif %}
                                 </em>

--- a/aiarena/frontend/templates/season.html
+++ b/aiarena/frontend/templates/season.html
@@ -68,7 +68,16 @@
                         {% else %}
                             <td>No stats</td>
                         {% endif %}
-                        <td>{{ participant.elo }}</td>
+                        <td>
+                            {{ participant.elo }}
+                            {% with trend=participant.bot.current_elo_trend %}
+                                <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">
+                                    {% if trend > 0 %} trending_up
+                                    {% elif trend < 0 %} trending_down
+                                    {% else %} fast_rewind
+                                    {% endif %}
+                                </em>
+                            {% endwith %}</td>
                         <td><a href="{% url 'bot_season_stats' participant.id participant.slug %}">Stats</a></td>
 
                     </tr>

--- a/aiarena/frontend/templates/season.html
+++ b/aiarena/frontend/templates/season.html
@@ -72,8 +72,8 @@
                             {{ participant.elo }}
                             {% with trend=participant.bot.current_elo_trend %}
                                 <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">
-                                    {% if trend > 0 %} trending_up
-                                    {% elif trend < 0 %} trending_down
+                                    {% if trend > 10 %} trending_up
+                                    {% elif trend < -10 %} trending_down
                                     {% else %} fast_rewind
                                     {% endif %}
                                 </em>

--- a/aiarena/settings.py
+++ b/aiarena/settings.py
@@ -210,6 +210,7 @@ CONSTANCE_CONFIG = {
     400, 'The maximum bot zip file size that a platinum supporter tier user can upload to the website.'),
     'BOT_ZIP_SIZE_LIMIT_IN_MB_DIAMOND_TIER': (
     500, 'The maximum bot zip file size that a diamond supporter tier user can upload to the website.'),
+    'ELO_TREND_N_MATCHES': (30, 'Number of matches to include in ELO trend calculation'),
     'ELO_DIFF_RATING_MODIFIER': (0.999, 'Affects how the ELO difference between bots in an upset match '
                                         '(lower ranked bot beats higher ranked) affects the interest score: ELO_DIFF_RATING_MODIFIER^ELO_DIFF-1'),
     'COMBINED_ELO_RATING_DIVISOR': (200, 'Controls how the combined bot ELO affects the interest score: '
@@ -231,7 +232,7 @@ CONSTANCE_CONFIG = {
 CONSTANCE_CONFIG_FIELDSETS = {
     'Bots': ('BOT_UPLOADS_ENABLED', 'MAX_USER_BOT_COUNT', 'MAX_USER_BOT_COUNT_ACTIVE_PER_RACE',),
     'General': ('DEBUG_LOGGING_ENABLED', 'GETTING_STARTED_URL', 'HOUSE_BOTS_USER_ID', 'ALLOW_REQUESTED_MATCHES',
-                'ENABLE_ELO_SANITY_CHECK', 'PUBLIC_BANNER_MESSAGE', 'LOGGED_IN_BANNER_MESSAGE'),
+                'ENABLE_ELO_SANITY_CHECK', 'PUBLIC_BANNER_MESSAGE', 'LOGGED_IN_BANNER_MESSAGE', 'ELO_TREND_N_MATCHES'),
     'Match Requests': ('MATCH_REQUEST_LIMIT_FREE_TIER', 'MATCH_REQUEST_LIMIT_BRONZE_TIER',
                        'MATCH_REQUEST_LIMIT_SILVER_TIER', 'MATCH_REQUEST_LIMIT_GOLD_TIER',
                        'MATCH_REQUEST_LIMIT_PLATINUM_TIER', 'MATCH_REQUEST_LIMIT_DIAMOND_TIER',


### PR DESCRIPTION
Add trend indicators to main ranking page #131 

I've also filtered out requested matches in `current_elo_trend` and made it so only elo changes greater than 10 show as a trend.