### PR TITLE
Better icons for trends

### DIFF
--- a/aiarena/frontend/templates/index.html
+++ b/aiarena/frontend/templates/index.html
@@ -65,9 +65,11 @@
                             {{ participant.elo }}
                             {% with trend=participant.bot.current_elo_trend %}
                                 <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">
-                                    {% if trend > 10 %} trending_up
-                                    {% elif trend < -10 %} trending_down
-                                    {% else %} fast_rewind
+                                    {% if trend > 40 %} arrow_upward
+                                    {% elif trend < -40 %} arrow_downward
+                                    {% elif trend > 15 %} trending_up
+                                    {% elif trend < -15 %} trending_down
+                                    {% else %} trending_flat
                                     {% endif %}
                                 </em>
                             {% endwith %}

--- a/aiarena/frontend/templates/season.html
+++ b/aiarena/frontend/templates/season.html
@@ -72,9 +72,11 @@
                             {{ participant.elo }}
                             {% with trend=participant.bot.current_elo_trend %}
                                 <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">
-                                    {% if trend > 10 %} trending_up
-                                    {% elif trend < -10 %} trending_down
-                                    {% else %} fast_rewind
+                                    {% if trend > 40 %} arrow_upward
+                                    {% elif trend < -40 %} arrow_downward
+                                    {% elif trend > 15 %} trending_up
+                                    {% elif trend < -15 %} trending_down
+                                    {% else %} trending_flat
                                     {% endif %}
                                 </em>
                             {% endwith %}</td>


### PR DESCRIPTION
Better icons for trends to reflect the bot performance hopefully more accurately.
Flat trend for no changes at all and arrow up / down for more than 40 elo change.
Also increased the "staying still" margin from 10 to 15 because the bot ELO does vary quite a bit even while nothing is happening.