### PR TITLE
Differentiate requested matches in result list

### DIFF
--- a/aiarena/frontend/templates/arenaclient.html
+++ b/aiarena/frontend/templates/arenaclient.html
@@ -90,15 +90,19 @@
                             </td>
 
                             <td style="padding-left: 0">
-                                {{ p.elo_change |format_elo_change }}
-                                {% if p.elo_change and p.elo_change != 0 %}
-                                    {% if p.elo_change > 0 %}
-                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_up</em>
-                                    {% elif p.elo_change < 0 %}
-                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_down</em>
-                                    {% endif %}
+                                {% if result.match.requested_by %}
+                                    --
                                 {% else %}
-                                    <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; ">trending_flat</em>
+                                    {{ p.elo_change |format_elo_change }}
+                                    {% if p.elo_change and p.elo_change != 0 %}
+                                        {% if p.elo_change > 0 %}
+                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_up</em>
+                                        {% elif p.elo_change < 0 %}
+                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_down</em>
+                                        {% endif %}
+                                    {% else %}
+                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; ">trending_flat</em>
+                                    {% endif %}
                                 {% endif %}
                             </td>
                         {% endif %}
@@ -115,15 +119,19 @@
                             </td>
 
                             <td style="padding-left: 0">
-                                {{ p.elo_change |format_elo_change }}
-                                {% if p.elo_change and p.elo_change != 0 %}
-                                    {% if p.elo_change > 0 %}
-                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_up</em>
-                                    {% elif p.elo_change < 0 %}
-                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_down</em>
-                                    {% endif %}
+                                {% if result.match.requested_by %}
+                                    --
                                 {% else %}
-                                    <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; ">trending_flat</em>
+                                    {{ p.elo_change |format_elo_change }}
+                                    {% if p.elo_change and p.elo_change != 0 %}
+                                        {% if p.elo_change > 0 %}
+                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_up</em>
+                                        {% elif p.elo_change < 0 %}
+                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_down</em>
+                                        {% endif %}
+                                    {% else %}
+                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; ">trending_flat</em>
+                                    {% endif %}
                                 {% endif %}
                             </td>
                         {% endif %}

--- a/aiarena/frontend/templates/bot.html
+++ b/aiarena/frontend/templates/bot.html
@@ -193,7 +193,13 @@
                         <td>{{ result.opponent.bot.as_html_link }}</td>
                         <td>{{ result.result }}</td>
                         <td>{{ result.result_cause }}</td>
-                        <td>{{ result.me.elo_change |format_elo_change }}</td>
+                        <td>
+                            {% if result.match.requested_by %}
+                                --
+                            {% else %}
+                                {{ result.me.elo_change |format_elo_change }}
+                            {% endif %}
+                        </td>
                         <td style='color: {{ result.me.step_time_ms|step_time_color }};'>{{ result.me.step_time_ms|floatformat:3 }}</td>
                         <td>{{ result.game_time_formatted }}</td>
                         {% if result.replay_file %}

--- a/aiarena/frontend/templates/match.html
+++ b/aiarena/frontend/templates/match.html
@@ -9,7 +9,7 @@
 
             {# Participant 1 #}
 
-            {% if match.result %}
+            {% if match.result and not match.requested_by %}
                 {# ELO movement indicator #}
                 {% if match.participant1.elo_change and match.participant1.elo_change != 0 %}
                     {% if match.participant1.elo_change > 0 %}
@@ -37,7 +37,7 @@
             {# Bot name #}
             {{ match.participant2.bot.as_html_link }}
 
-            {% if match.result %}
+            {% if match.result and not match.requested_by %}
                 {# ELO change #}
                 ({{ match.participant2.elo_change|format_elo_change }})
 
@@ -58,6 +58,9 @@
         </h2>
         <h3>On:</h3>
         <h2>{{ match.map }}</h2>
+        {% if match.requested_by %}
+            <h4>Requested by {{ match.requested_by.as_html_link }}</h4>
+        {% endif %}
 
 
     </div>

--- a/aiarena/frontend/templates/results.html
+++ b/aiarena/frontend/templates/results.html
@@ -33,15 +33,19 @@
                         </td>
 
                         <td style="padding-left: 0">
-                            {{ p.elo_change |format_elo_change }}
-                            {% if p.elo_change and p.elo_change != 0 %}
-                                {% if p.elo_change > 0 %}
-                                    <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_up</em>
-                                {% elif p.elo_change < 0 %}
-                                    <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_down</em>
-                                {% endif %}
+                            {% if result.match.requested_by %}
+                                --
                             {% else %}
-                                <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; ">trending_flat</em>
+                                {{ p.elo_change |format_elo_change }}
+                                {% if p.elo_change and p.elo_change != 0 %}
+                                    {% if p.elo_change > 0 %}
+                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_up</em>
+                                    {% elif p.elo_change < 0 %}
+                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_down</em>
+                                    {% endif %}
+                                {% else %}
+                                    <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; ">trending_flat</em>
+                                {% endif %}
                             {% endif %}
                         </td>
                     {% endif %}
@@ -58,15 +62,19 @@
                         </td>
 
                         <td style="padding-left: 0">
-                            {{ p.elo_change |format_elo_change }}
-                            {% if p.elo_change and p.elo_change != 0 %}
-                                {% if p.elo_change > 0 %}
-                                    <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_up</em>
-                                {% elif p.elo_change < 0 %}
-                                    <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_down</em>
-                                {% endif %}
+                            {% if result.match.requested_by %}
+                                --
                             {% else %}
-                                <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; ">trending_flat</em>
+                                {{ p.elo_change |format_elo_change }}
+                                {% if p.elo_change and p.elo_change != 0 %}
+                                    {% if p.elo_change > 0 %}
+                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_up</em>
+                                    {% elif p.elo_change < 0 %}
+                                        <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;">trending_down</em>
+                                    {% endif %}
+                                {% else %}
+                                    <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; ">trending_flat</em>
+                                {% endif %}
                             {% endif %}
                         </td>
                     {% endif %}

--- a/aiarena/frontend/templatetags/core_filters.py
+++ b/aiarena/frontend/templatetags/core_filters.py
@@ -10,7 +10,7 @@ def cents_to_usd(cents):
 def format_elo_change(value):
     """Custom formatting for ELO change integers"""
     if value is None or value == 0:
-        return "--"
+        return "0"
     else:
         return "%+d" % value
 

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -332,6 +332,7 @@ class Ranking(TemplateView):
 class Results(ListView):
     queryset = Result.objects.all().order_by('-created').prefetch_related(
         Prefetch('winner'),
+        Prefetch('match__requested_by'),
         Prefetch('match__matchparticipation_set', MatchParticipation.objects.all().prefetch_related('bot'),
                  to_attr='participants'))
     template_name = 'results.html'


### PR DESCRIPTION
#89 Differentiate requested matches in result list

- Ladder games with no ELO change will show as 0, whereas requested matches will show as "--" with no trend icons in bot.html, match.html, arenaclient.html and results.html

- User that requested the match can be seen on the match page

Results Page
![image](https://user-images.githubusercontent.com/13944193/100607780-8a4ace00-335f-11eb-899f-564e3d32a6a7.png)

Bot Page
![image](https://user-images.githubusercontent.com/13944193/100607855-a9e1f680-335f-11eb-91f3-1ca7536909eb.png)

Match Page
![image](https://user-images.githubusercontent.com/13944193/100607896-b5cdb880-335f-11eb-919d-ebdc7e481640.png)

Arenaclient Page
![image](https://user-images.githubusercontent.com/13944193/100607943-c8e08880-335f-11eb-85b7-09015f9e5bea.png)
