### PR TITLE
List requested matches for bot authors in their profile page and allow cancellations

### DIFF
--- a/aiarena/core/models/user.py
+++ b/aiarena/core/models/user.py
@@ -93,8 +93,11 @@ class User(AbstractUser):
     @property
     def match_request_count_left(self):
         from .match import Match
+        from .result import Result
         return self.requested_matches_limit \
                - Match.objects.only('id').filter(requested_by=self,
+                                      created__gte=timezone.now() - config.REQUESTED_MATCHES_LIMIT_PERIOD).count() \
+               + Result.objects.only('id').filter(submitted_by=self, type='MatchCancelled',
                                       created__gte=timezone.now() - config.REQUESTED_MATCHES_LIMIT_PERIOD).count()
 
     @property

--- a/aiarena/core/tests/tests.py
+++ b/aiarena/core/tests/tests.py
@@ -188,6 +188,13 @@ class BaseTestMixin(object):
         bot = Bot.get_random_active()
         Matches.request_match(self.regularUser2, bot, bot.get_random_active_excluding_self())
 
+        # generate match requests from regularUser1
+        bot = Bot.get_random_active()
+        Matches.request_match(self.regularUser1, bot, bot.get_random_active_excluding_self())
+        Matches.request_match(self.regularUser1, bot, bot.get_random_active_excluding_self())
+        bot = Bot.get_random_active()
+        Matches.request_match(self.regularUser1, bot, bot.get_random_active_excluding_self())
+
         self.client.logout()  # child tests can login if they require
 
     def _generate_match_activity(self):

--- a/aiarena/frontend/static/style.css
+++ b/aiarena/frontend/static/style.css
@@ -962,6 +962,18 @@ background-color: #3d4536;
     margin: 10px 0 10px 0;
 }
 
+.profile-cancel-matches-button {
+    text-align: center;
+    height: 30px;
+    font-size: 18px;
+    background-color: #61892f;
+    color: white;
+    font-family: 'Quicksand', sans-serif;
+    font-weight: bold;
+    border: 0;
+    margin: 10px 0 10px 0;
+}
+
 #discord-link-button:hover {
     background-color: #86c232;
 }

--- a/aiarena/frontend/templates/profile.html
+++ b/aiarena/frontend/templates/profile.html
@@ -94,4 +94,47 @@
             </tr>
         {% endfor %}
     </table>
+    {% if requested_matches %}
+        <div class="divider"><span></span><span><h2>Requested matches</h2></span><span></span></div>
+        <table summary="Table containing information about requested matches" class="row-hover-highlight">
+            <thead>
+            <tr>
+                <td><strong>Match ID</strong></td>
+                <td><strong>Bot 1</strong></td>
+                <td><strong>Bot 2</strong></td>
+                <td><strong>Map</strong></td>
+                <td><strong>Started at</strong></td>
+                <td><strong>Assigned to</strong></td>
+            </tr>
+            </thead>
+            <tbody>
+            {% for match in requested_matches %}
+                <tr>
+                    <td>{{ match.as_html_link }}</td>
+                    {% for p in match.participants %}
+                        {% if p.participant_number == 1 %}
+                            <td>{{ p.bot.as_html_link }}</td>
+                        {% endif %}
+                    {% endfor %}
+                    {% for p in match.participants %}
+                        {% if p.participant_number == 2 %}
+                            <td>{{ p.bot.as_html_link }}</td>
+                        {% endif %}
+                    {% endfor %}
+                    <td>{{ match.map }}</td>
+                    {% if match.started %}
+                        <td>{{ match.started|date:"d. N Y - H:i:s" }}</td>
+                    {% else %}
+                        <td>queued...</td>
+                    {% endif %}
+                    {% if match.assigned_to %}
+                        <td>{{ match.assigned_to.as_html_link }}</td>
+                    {% else %}
+                        <td>queued...</td>
+                    {% endif %}
+                </tr>
+            {% endfor %}
+            <tbody>
+        </table>
+    {% endif %}
 {% endblock %}

--- a/aiarena/frontend/templates/profile.html
+++ b/aiarena/frontend/templates/profile.html
@@ -96,45 +96,55 @@
     </table>
     {% if requested_matches %}
         <div class="divider"><span></span><span><h2>Requested matches</h2></span><span></span></div>
-        <table summary="Table containing information about requested matches" class="row-hover-highlight">
-            <thead>
-            <tr>
-                <td><strong>Match ID</strong></td>
-                <td><strong>Bot 1</strong></td>
-                <td><strong>Bot 2</strong></td>
-                <td><strong>Map</strong></td>
-                <td><strong>Started at</strong></td>
-                <td><strong>Assigned to</strong></td>
-            </tr>
-            </thead>
-            <tbody>
-            {% for match in requested_matches %}
+        <form method="post">
+            {% csrf_token %}
+            <span style="margin-left:60px; display: inline;">
+                <input class="profile-cancel-matches-button"  type="submit" value="Cancel Selected Matches"/>
+            </span>
+            <table summary="Table containing information about requested matches" class="row-hover-highlight">
+                <thead>
                 <tr>
-                    <td>{{ match.as_html_link }}</td>
-                    {% for p in match.participants %}
-                        {% if p.participant_number == 1 %}
-                            <td>{{ p.bot.as_html_link }}</td>
-                        {% endif %}
-                    {% endfor %}
-                    {% for p in match.participants %}
-                        {% if p.participant_number == 2 %}
-                            <td>{{ p.bot.as_html_link }}</td>
-                        {% endif %}
-                    {% endfor %}
-                    <td>{{ match.map }}</td>
-                    {% if match.started %}
-                        <td>{{ match.started|date:"d. N Y - H:i:s" }}</td>
-                    {% else %}
-                        <td>queued...</td>
-                    {% endif %}
-                    {% if match.assigned_to %}
-                        <td>{{ match.assigned_to.as_html_link }}</td>
-                    {% else %}
-                        <td>queued...</td>
-                    {% endif %}
+                    <td><strong>Match ID</strong></td>
+                    <td><strong>Bot 1</strong></td>
+                    <td><strong>Bot 2</strong></td>
+                    <td><strong>Map</strong></td>
+                    <td><strong>Started at</strong></td>
+                    <td><strong>Assigned to</strong></td>
                 </tr>
-            {% endfor %}
-            <tbody>
-        </table>
+                </thead>
+                <tbody>
+                {% for match in requested_matches %}
+                    <tr>
+                        {% if match.assigned_to %}
+                            <td>{{ match.as_html_link }}</td>
+                        {% else %}
+                            <td><input type="checkbox" name="match_selection" value="{{ match.id }}">{{ match.as_html_link }}</td>
+                        {% endif %}
+                        {% for p in match.participants %}
+                            {% if p.participant_number == 1 %}
+                                <td>{{ p.bot.as_html_link }}</td>
+                            {% endif %}
+                        {% endfor %}
+                        {% for p in match.participants %}
+                            {% if p.participant_number == 2 %}
+                                <td>{{ p.bot.as_html_link }}</td>
+                            {% endif %}
+                        {% endfor %}
+                        <td>{{ match.map }}</td>
+                        {% if match.started %}
+                            <td>{{ match.started|date:"d. N Y - H:i:s" }}</td>
+                        {% else %}
+                            <td>queued...</td>
+                        {% endif %}
+                        {% if match.assigned_to %}
+                            <td>{{ match.assigned_to.as_html_link }}</td>
+                        {% else %}
+                            <td>queued...</td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+                <tbody>
+            </table>
+        </form>
     {% endif %}
 {% endblock %}

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -54,6 +54,11 @@ class UserProfile(LoginRequiredMixin, DetailView):
         context['bot_list'] = self.request.user.bots.all()
         context['max_user_bot_count'] = config.MAX_USER_BOT_COUNT
         context['max_active_per_race_bot_count'] = self.request.user.get_active_bots_per_race_limit_display()
+        context['requested_matches'] = Match.objects.filter(requested_by=self.object, result__isnull=True).order_by(
+            F('started').asc(nulls_last=True), F('id').asc()).prefetch_related(
+            Prefetch('map'),
+            Prefetch('matchparticipation_set', MatchParticipation.objects.all().prefetch_related('bot'),
+                     to_attr='participants'))
         return context
 
 


### PR DESCRIPTION
#87 and #138 

- Requested matches appear on User Profile.
- User can cancel matches requested by them from their profile page.
- Only matches that haven't been assigned to an arena client can be cancelled.
- On success or failure, a message will display at the top of the page.
- Right now only matches cancelled by them will refund their match requests.

@lladdy @eladyaniv01 
I'm not sure if the way I implemented it is the best way to do it, do let me know if you can think of how to improve it.

![image](https://user-images.githubusercontent.com/13944193/101239717-f487b800-373d-11eb-8ec7-153b0dc27700.png)
