### PR TITLE
List matches that are being played or have been queued on the bot page

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -36,7 +36,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install 
         python ./pip/pip-install.py --python=python --pip=pip
     - name: Verify MariaDB connection
       env:

--- a/aiarena/frontend/templates/bot.html
+++ b/aiarena/frontend/templates/bot.html
@@ -166,6 +166,50 @@
             </tfoot>
         </table>
     </div>
+    {% if match_participations %}
+        <div id="bot_matches_anker"></div>
+        <div class="divider"><span></span><span><h2>Matches</h2></span><span></span></div>
+        <table summary="Table containing information about queued or in progress matches" class="row-hover-highlight">
+            <thead>
+            <tr>
+                <td><strong>Match ID</strong></td>
+                <td><strong>Bot 1</strong></td>
+                <td><strong>Bot 2</strong></td>
+                <td><strong>Map</strong></td>
+                <td><strong>Started at</strong></td>
+                <td><strong>Assigned to</strong></td>
+            </tr>
+            </thead>
+            <tbody>
+            {% for participation in match_participations %}
+                <tr>
+                    <td>{{ participation.match.as_html_link }}</td>
+                    {% for p in participation.match.participants %}
+                        {% if p.participant_number == 1 %}
+                            <td>{{ p.bot.as_html_link }}</td>
+                        {% endif %}
+                    {% endfor %}
+                    {% for p in participation.match.participants %}
+                        {% if p.participant_number == 2 %}
+                            <td>{{ p.bot.as_html_link }}</td>
+                        {% endif %}
+                    {% endfor %}
+                    <td>{{ participation.match.map }}</td>
+                    {% if participation.match.started %}
+                        <td>{{ participation.match.started|date:"d. N Y - H:i:s" }}</td>
+                    {% else %}
+                        <td>queued...</td>
+                    {% endif %}
+                    {% if participation.match.assigned_to %}
+                        <td>{{ participation.match.assigned_to.as_html_link }}</td>
+                    {% else %}
+                        <td>queued...</td>
+                    {% endif %}
+                </tr>
+            {% endfor %}
+            <tbody>
+        </table>
+    {% endif %}
     <div id="bot_results_anker"></div>
     <div class="divider"><span></span><span><h2>Results</h2></span><span></span></div>
     <div id="bot_results">


### PR DESCRIPTION
#86 

Limiting the matches shown to matches being played seems to limit the use of this feature a lot, so I decided to make it show queued matches as well. 

If anyone has any ideas, I would like to know if there's a better way to do the query, the way I've done it isn't particularly elegant.

![image](https://user-images.githubusercontent.com/13944193/102002152-e6452780-3d4d-11eb-85ca-b42e21f8ed3c.png)
