### PR TITLE
Prevent pip upgrade

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -36,7 +36,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
         python ./pip/pip-install.py --python=python --pip=pip
     - name: Verify MariaDB connection
       env:


### PR DESCRIPTION
Latest version of pip causing issues with build:
https://github.com/pypa/pip/issues/9203#issuecomment-740967395

Leaving pip unupgraded should fix issue.