### PR TITLE
Limit matches shown on bot page to requested or in progress

### DIFF
--- a/aiarena/frontend/templates/bot.html
+++ b/aiarena/frontend/templates/bot.html
@@ -168,7 +168,7 @@
     </div>
     {% if match_participations %}
         <div id="bot_matches_anker"></div>
-        <div class="divider"><span></span><span><h2>Matches</h2></span><span></span></div>
+        <div class="divider"><span></span><span><h2>Requested or In Progress Matches</h2></span><span></span></div>
         <table summary="Table containing information about queued or in progress matches" class="row-hover-highlight">
             <thead>
             <tr>

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -9,7 +9,7 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.db import transaction, IntegrityError
-from django.db.models import F, Prefetch
+from django.db.models import F, Prefetch, Q
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.utils import timezone
@@ -234,7 +234,7 @@ class BotDetail(DetailView):
         context['bot_trophies'] = Trophy.objects.filter(bot=self.object)
         context['rankings'] = self.object.seasonparticipation_set.all().order_by('-id')
         context['match_participations'] = MatchParticipation.objects.only("match")\
-            .filter(bot=self.object, match__result__isnull=True)\
+            .filter(Q(match__requested_by__isnull=False)|Q(match__assigned_to__isnull=False), bot=self.object, match__result__isnull=True)\
             .order_by(F('match__started').asc(nulls_last=True), F('match__id').asc())\
             .prefetch_related(
                 Prefetch('match__map'), 


### PR DESCRIPTION
The matches table is too long when including queued ladder matches, limiting what is shown to reduce clutter.