### PR TITLE
Improve result filtering

### DIFF
--- a/aiarena/frontend/static/style.css
+++ b/aiarena/frontend/static/style.css
@@ -66,7 +66,7 @@ a {
 }
 
 a.file-link:visited {
-    color: #61892f;
+    color: red;
 }
 
 .material-icons {

--- a/aiarena/frontend/templates/bot.html
+++ b/aiarena/frontend/templates/bot.html
@@ -214,27 +214,47 @@
     <div id="bot_results">
         <form method="get" class="filter-form flex-container" style="margin-bottom: 30px">
             {{ filter.form.non_field_errors }}
-            <div class="flex-row-short" style="width: 35%">
+            <div class="flex-row-short" style="width: 23%">
                 {{ filter.form.opponent.errors }}
                 <label for="{{ filter.form.opponent.id_for_label }}">Opponent:</label>
                 {{ filter.form.opponent }}
             </div>
-            <div class="flex-row-short" style="width: 20%">
+            <div class="flex-row-short" style="width: 13%">
+                {{ filter.form.race.errors }}
+                <label for="{{ filter.form.race.id_for_label }}">Race:</label>
+                {{ filter.form.race }}
+            </div>
+            <div class="flex-row-short" style="width: 12%">
                 {{ filter.form.result.errors }}
                 <label for="{{ filter.form.result.id_for_label }}">Result:</label>
                 {{ filter.form.result }}
             </div>
-            <div class="flex-row-short">
+            <div class="flex-row-short" style="width: 20%">
                 {{ filter.form.result_cause.errors }}
                 <label for="{{ filter.form.result_cause.id_for_label }}">Cause:</label>
                 {{ filter.form.result_cause }}
             </div>
-            <div class="flex-row-half" style="width: 100%">
+            <div class="flex-row-short" style="width: 18%">
                 {{ filter.form.avg_step_time.errors }}
                 <label for="{{ filter.form.avg_step_time.id_for_label }}">Avg Step (ms):</label>
                 {{ filter.form.avg_step_time }}
             </div>
-            <div class="flex-row-short">
+            <div class="flex-row-short" style="width: 16%">
+                {{ filter.form.match_type.errors }}
+                <label for="{{ filter.form.match_type.id_for_label }}">Match Type:</label>
+                {{ filter.form.match_type }}
+            </div>
+            <div class="flex-row-short" style="width: 17%">
+                {{ filter.form.competition.errors }}
+                <label for="{{ filter.form.competition.id_for_label }}">Competition:</label>
+                {{ filter.form.competition }}
+            </div>
+            <div class="flex-row-short" style="width: 23%">
+                {{ filter.form.map.errors }}
+                <label for="{{ filter.form.map.id_for_label }}">Map:</label>
+                {{ filter.form.map }}
+            </div>
+            <div class="flex-row-half" style="width: 100%">
                 <input id=submit-button type="submit" value="Filter" />
             </div>
         </form>

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -236,8 +236,8 @@ class BotResultTable(tables.Table):
         verbose_name="Avg Step(ms)",
         attrs={"td": {"style": lambda value: f"color: {step_time_color(value)};'"}})
     game_time_formatted = tables.Column(verbose_name="Duration")
-    replay_file = FileURLColumn(verbose_name="Replay", orderable=False)
-    match_log = FileURLColumn(verbose_name="Log", orderable=False)
+    replay_file = FileURLColumn(verbose_name="Replay", orderable=False, attrs={"a": {"class": "file-link"}})
+    match_log = FileURLColumn(verbose_name="Log", orderable=False, attrs={"a": {"class": "file-link"}})
 
     # Settings for the Table
     class Meta:

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -25,6 +25,7 @@ from wiki.models import ArticleRevision
 import django_tables2 as tables
 from django_tables2 import RequestConfig, SingleTableMixin
 import django_filters as filters
+from django_filters.widgets import RangeWidget
 
 from aiarena.core.api.maps import Maps
 from aiarena.frontend.templatetags.core_filters import step_time_color, format_elo_change
@@ -273,14 +274,25 @@ class BotResultTable(tables.Table):
 
 
 class RelativeResultFilter(filters.FilterSet):
-    opponent = filters.CharFilter(label='Opponent', field_name='opponent__bot__name', lookup_expr='contains')
+    MATCH_TYPES = (
+        ("competition", "Competition"),
+        ("requested", "Requested"),
+    )
+
+    opponent = filters.CharFilter(label='Opponent', field_name='opponent__bot__name', lookup_expr='icontains')
+    race = filters.ChoiceFilter(label="Race", choices=Bot.RACES, field_name='opponent__bot__plays_race')
     result = filters.ChoiceFilter(label='Result', choices=MatchParticipation.RESULT_TYPES[1:])
     result_cause = filters.ChoiceFilter(label='Cause', choices=MatchParticipation.CAUSE_TYPES)
-    avg_step_time = filters.RangeFilter(label="Average Step Time", method="filter_avg_step_time")
+    avg_step_time = filters.RangeFilter(label="Average Step Time", method="filter_avg_step_time",
+                                        widget=RangeWidget(attrs={"size": 4}))
+    match_type = filters.ChoiceFilter(label='Match Type', choices=MATCH_TYPES, method="filter_match_types")
+    competition = filters.ModelChoiceFilter(label="Competition", queryset=Competition.objects.all(),
+                                            field_name='match__round__competition')
+    map = filters.CharFilter(label='Map', field_name='match__map__name', lookup_expr='icontains')
 
     class Meta:
         model = RelativeResult
-        fields = ['opponent', 'result', 'result_cause', 'avg_step_time']
+        fields = ['opponent__bot__name', 'opponent__bot__plays_race', 'result', 'result_cause', 'avg_step_time']
 
     # Custom filter to match scale
     def filter_avg_step_time(self, queryset, name, value):
@@ -291,6 +303,13 @@ class RelativeResultFilter(filters.FilterSet):
                 return queryset.filter(avg_step_time__gte=value.start/1000)
             elif value.stop is not None:
                 return queryset.filter(avg_step_time__lte=value.stop/1000)
+        return queryset
+
+    def filter_match_types(self, queryset, name, value):
+        if value == self.MATCH_TYPES[0][0]:
+            return queryset.filter(match__requested_by__isnull=True)
+        elif value == self.MATCH_TYPES[1][0]:
+            return queryset.filter(match__requested_by__isnull=False)
         return queryset
 
 


### PR DESCRIPTION
Fixed "used" file link colorl, opponent search now case-insensitive, can filter by competition/requested/map

![image](https://user-images.githubusercontent.com/13944193/106441468-2fa03080-64ce-11eb-8ddd-07404c5ca5f9.png)
