### PR TITLE
Delete orphaned MatchTag and Tag via signals, allow empty tag form, strip tags when cleaning

### DIFF
--- a/aiarena/core/models/match_tag.py
+++ b/aiarena/core/models/match_tag.py
@@ -1,6 +1,8 @@
 import logging
 
 from django.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 
 from .user import User
 from .tag import Tag
@@ -14,3 +16,10 @@ class MatchTag(models.Model):
 
     def __str__(self):
         return f"{str(self.tag)} ({self.user.username})"
+
+
+@receiver(post_delete, sender=MatchTag)
+def delete_orphan_tags(sender, instance, **kwargs):
+    # If there are no objects that refer to this tag left, delete the tag
+    if not sender.objects.filter(tag=instance.tag):
+        instance.tag.delete()


### PR DESCRIPTION
- MatchTag and Tag that are not in use will be removed automatically
- Allowing empty MatchTagForm will allow complete removal of tags from a match
- Stripping tags when cleaning to prevent new Tags from being created due to whitespace