### PR TITLE
Prevent error when stats generation has not been run for a bot

### DIFF
--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -395,7 +395,7 @@ class BotCompetitionStatsDetail(DetailView):
         context = super().get_context_data(**kwargs)
         context['competition_bot_matchups'] = self.object.competition_matchup_stats.filter(
             opponent__competition=context['competitionparticipation'].competition).order_by('-win_perc').distinct()
-        context['updated'] = context['competition_bot_matchups'][0].updated
+        context['updated'] = context['competition_bot_matchups'][0].updated if context['competition_bot_matchups'] else "Never"
         return context
 
 


### PR DESCRIPTION
Fixes #205 

As I mentioned in the issue, my understanding is that the thing that generates stats is run periodically and this error occurs when the stats page is requested and the job hasn't been run. So the fix is just to return a default string if there is no data.

Result:
![image](https://user-images.githubusercontent.com/13944193/108001491-b01f6f00-7040-11eb-8a3b-b23df65e9d5f.png)
