### PR TITLE
Filter for competition matches in trend calculation

### DIFF
--- a/aiarena/core/models/bot.py
+++ b/aiarena/core/models/bot.py
@@ -80,11 +80,10 @@ class Bot(models.Model, LockableModelMixin):
     game_display_id = models.UUIDField(default=uuid.uuid4)
     wiki_article = models.OneToOneField(Article, on_delete=models.PROTECT, blank=True, null=True)
 
-    @property
-    def current_elo_trend(self):
+    def current_elo_trend(self, competition):
         from .relative_result import RelativeResult
         return (RelativeResult.objects
-            .filter(me__bot=self, match__requested_by__isnull=True)
+            .filter(me__bot=self, match__requested_by__isnull=True, match__round__competition=competition)
             .order_by('-created')[:config.ELO_TREND_N_MATCHES]
             .aggregate(Sum('elo_change'))['elo_change__sum'])
 

--- a/aiarena/frontend/templates/competition.html
+++ b/aiarena/frontend/templates/competition.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n core_filters %}
 
 {% block content %}
 
@@ -70,7 +70,7 @@
                         {% endif %}
                         <td>
                             {{ participant.elo }}
-                            {% with trend=participant.bot.current_elo_trend %}
+                            {% bot_competition_trend participant.bot competition as trend %}
                                 {% if trend > 40 %}
                                     <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; transform: rotate(-90deg);" title="ELO gained {{trend}} in the last 30 games">
                                         trending_flat
@@ -92,7 +92,7 @@
                                         trending_flat
                                     </em>
                                 {% endif %}
-                            {% endwith %}</td>
+                            </td>
                         <td><a href="{% url 'bot_competition_stats' participant.id participant.slug %}">Stats</a></td>
 
                     </tr>

--- a/aiarena/frontend/templatetags/core_filters.py
+++ b/aiarena/frontend/templatetags/core_filters.py
@@ -105,6 +105,10 @@ def shorten_naturaltime(naturaltime):
             .replace(' years', 'y').replace(' year', 'y'))
 
 
+def bot_competition_trend(bot, competition):
+    return bot.current_elo_trend(competition)
+
+
 register = template.Library()
 register.filter('pretty_bool', pretty_bool)
 register.filter('format_elo_change', format_elo_change)
@@ -112,3 +116,4 @@ register.filter('smooth_timedelta', smooth_timedelta)
 register.filter('cents_to_usd', cents_to_usd)
 register.filter('step_time_color', step_time_color)
 register.filter('shorten_naturaltime', shorten_naturaltime)
+register.simple_tag(bot_competition_trend, name='bot_competition_trend')


### PR DESCRIPTION
Fixes #197 by filtering for only the matches is a given competition.

Competition 1:
![image](https://user-images.githubusercontent.com/13944193/108005501-fc70ac00-704c-11eb-9dfc-38b32d254b24.png)

Competition 2:
![image](https://user-images.githubusercontent.com/13944193/108005523-0b575e80-704d-11eb-8363-337d6c2aa09e.png)
