### PR TITLE
fix: correctly show dates on graph

### DIFF
--- a/aiarena/core/stats/stats_generator.py
+++ b/aiarena/core/stats/stats_generator.py
@@ -194,23 +194,21 @@ class StatsGenerator:
     @staticmethod
     def _generate_plot_image(df):
         plot = io.BytesIO()
-        ax = plt.gca()
-        plt.rc('xtick', labelsize=22)
-        graph = df.plot(kind='line', x='Date', y='ELO', ax=ax, figsize=(12, 9), color=('#86c232'))
-        graph.spines["top"].set_visible(False)
-        graph.spines["right"].set_visible(False)
-        graph.spines["left"].set_color('#86c232')
-        graph.spines["bottom"].set_color('#86c232')
-        graph.autoscale(enable=True, axis='x')
-        graph.get_xaxis().tick_bottom()
-        graph.get_yaxis().tick_left()
 
-        plt.title('ELO over time', fontsize=20, color=('#86c232'))
-        plt.xticks()
+        fig, ax = plt.subplots(figsize=(12, 9))
+        ax.plot(df["Date"], df['ELO'], color='#86c232')
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.spines["left"].set_color('#86c232')
+        ax.spines["bottom"].set_color('#86c232')
+        ax.autoscale(enable=True, axis='x')
+        ax.get_xaxis().tick_bottom()
+        ax.get_yaxis().tick_left()
         ax.xaxis.set_major_formatter(mdates.DateFormatter('%b-%d'))
         ax.tick_params(axis='x', colors='#86c232', labelsize=16)
         ax.tick_params(axis='y', colors='#86c232', labelsize=16)
-        ax.get_legend().remove()
+        plt.title('ELO over time', fontsize=20, color=('#86c232'))
+
         plt.tight_layout()  # Avoids savefig cutting off x-label
         plt.savefig(plot, format="png", transparent=True)
         plt.cla()  # Clears axis in preparation for new graph
@@ -221,6 +219,7 @@ class StatsGenerator:
         df = StatsGenerator._get_data(bot_id)
         if not df.empty:
             df['1'] = pd.to_numeric(df['1'])
+            df['2'] = pd.to_datetime(df['2'])
             df.columns = ['Name', 'ELO', 'Date']
 
             return StatsGenerator._generate_plot_image(df)


### PR DESCRIPTION
Fixes #177 and #129 

original method causing weird erroneous interaction between datetime and matplotlib, thus I rewrote it to avoid df.plot()

![image](https://user-images.githubusercontent.com/13944193/108068274-fb279980-70b5-11eb-9c71-2474a6d567d5.png)


Set labels to H:M:S to check that the xlabels are right
![image](https://user-images.githubusercontent.com/13944193/108068020-af74f000-70b5-11eb-81a7-50c1d14af6bc.png)

