### PR TITLE
feat: Match result filters can now collapse to save space

### DIFF
--- a/aiarena/frontend/static/style.css
+++ b/aiarena/frontend/static/style.css
@@ -1391,3 +1391,40 @@ input[type=text], input[type=password], input[type=email], input[type=number], i
     content: "\6b";
     color: #800000;
 }
+
+.collapsible {
+  background-color: rgba(97, 137, 47, 0.7);
+  color: white;
+  cursor: pointer;
+  padding: 9px;
+  width: 90.1%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-family: 'Quicksand', sans-serif;
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.collapsible:after {
+  content: '\02795'; /* Unicode character for "plus" sign (+) */
+  float: right;
+  margin-left: 5px;
+}
+
+.collapsible-active:after {
+  content: "\2796"; /* Unicode character for "minus" sign (-) */
+}
+
+.collapsible-active, .collapsible:hover {
+  background-color: rgba(97, 137, 47, 1);
+}
+
+.collapsible-content {
+  padding: 0 30px;
+  background-color: rgba(0,0,0,0.25);
+  max-height: 0;
+  width: 84.5%;
+  overflow: hidden;
+  transition: max-height 0.2s ease-out
+}

--- a/aiarena/frontend/templates/bot.html
+++ b/aiarena/frontend/templates/bot.html
@@ -212,60 +212,79 @@
     <div id="bot_results_anker"></div>
     <div class="divider"><span></span><span><h2>Results</h2></span><span></span></div>
     <div id="bot_results">
-        <form method="get" class="filter-form flex-container" style="margin-bottom: 30px">
-            {{ filter.form.non_field_errors }}
-            <div class="flex-row-short" style="width: 23%">
-                {{ filter.form.opponent.errors }}
-                <label for="{{ filter.form.opponent.id_for_label }}">Opponent</label>
-                {{ filter.form.opponent }}
-            </div>
-            <div class="flex-row-short" style="width: 13%">
-                {{ filter.form.race.errors }}
-                <label for="{{ filter.form.race.id_for_label }}">Race</label>
-                {{ filter.form.race }}
-            </div>
-            <div class="flex-row-short" style="width: 12%">
-                {{ filter.form.result.errors }}
-                <label for="{{ filter.form.result.id_for_label }}">Result</label>
-                {{ filter.form.result }}
-            </div>
-            <div class="flex-row-short" style="width: 20%">
-                {{ filter.form.result_cause.errors }}
-                <label for="{{ filter.form.result_cause.id_for_label }}">Cause</label>
-                {{ filter.form.result_cause }}
-            </div>
-            <div class="flex-row-short" style="width: 18%">
-                {{ filter.form.avg_step_time.errors }}
-                <label for="{{ filter.form.avg_step_time.id_for_label }}">Avg Step (ms)</label>
-                {{ filter.form.avg_step_time }}
-            </div>
-            <div class="flex-row-short" style="width: 16%">
-                {{ filter.form.match_type.errors }}
-                <label for="{{ filter.form.match_type.id_for_label }}">Match Type</label>
-                {{ filter.form.match_type }}
-            </div>
-            <div class="flex-row-short" style="width: 23%">
-                {{ filter.form.map.errors }}
-                <label for="{{ filter.form.map.id_for_label }}">Map</label>
-                {{ filter.form.map }}
-            </div>
-            <div class="flex-row-short">
-                {{ filter.form.competition.errors }}
-                <label for="{{ filter.form.competition.id_for_label }}">Competition</label>
-                {{ filter.form.competition }}
-            </div>
-                {% if user.is_authenticated %}
-                    <div class="flex-row-half">
-                        {{ filter.form.tags.errors }}
-                        <label for="{{ filter.form.tags.id_for_label }}">Tags (comma separated)</label>
-                        {{ filter.form.tags }}
-                    </div>
-                {% endif %}
-            <div class="flex-row-half" style="width: 100%">
-                <input id=submit-button type="submit" value="Filter" />
-            </div>
-        </form>
+        <button class="collapsible filter-form">Filters</button>
+        <div class="collapsible-content filter-form" style="margin-bottom: 30px">
+            <form method="get" class="flex-container" style="justify-content: left">
+                {{ filter.form.non_field_errors }}
+                <div class="flex-row-short" style="width: 25%">
+                    {{ filter.form.opponent.errors }}
+                    <label for="{{ filter.form.opponent.id_for_label }}">Opponent</label>
+                    {{ filter.form.opponent }}
+                </div>
+                <div class="flex-row-short" style="width: 13%">
+                    {{ filter.form.race.errors }}
+                    <label for="{{ filter.form.race.id_for_label }}">Race</label>
+                    {{ filter.form.race }}
+                </div>
+                <div class="flex-row-short" style="width: 13%">
+                    {{ filter.form.result.errors }}
+                    <label for="{{ filter.form.result.id_for_label }}">Result</label>
+                    {{ filter.form.result }}
+                </div>
+                <div class="flex-row-short" style="width: 22%">
+                    {{ filter.form.result_cause.errors }}
+                    <label for="{{ filter.form.result_cause.id_for_label }}">Cause</label>
+                    {{ filter.form.result_cause }}
+                </div>
+                <div class="flex-row-short" style="width: 20%">
+                    {{ filter.form.avg_step_time.errors }}
+                    <label for="{{ filter.form.avg_step_time.id_for_label }}">Avg Step (ms)</label>
+                    {{ filter.form.avg_step_time }}
+                </div>
+                <div class="flex-row-short" style="width: 16%">
+                    {{ filter.form.match_type.errors }}
+                    <label for="{{ filter.form.match_type.id_for_label }}">Match Type</label>
+                    {{ filter.form.match_type }}
+                </div>
+                <div class="flex-row-short" style="width: 24%">
+                    {{ filter.form.map.errors }}
+                    <label for="{{ filter.form.map.id_for_label }}">Map</label>
+                    {{ filter.form.map }}
+                </div>
+                <div class="flex-row-short">
+                    {{ filter.form.competition.errors }}
+                    <label for="{{ filter.form.competition.id_for_label }}">Competition</label>
+                    {{ filter.form.competition }}
+                </div>
+                    {% if user.is_authenticated %}
+                        <div class="flex-row-half">
+                            {{ filter.form.tags.errors }}
+                            <label for="{{ filter.form.tags.id_for_label }}">Tags (comma separated)</label>
+                            {{ filter.form.tags }}
+                        </div>
+                    {% endif %}
+                <div class="flex-row-half" style="width: 100%; padding-bottom: 25px">
+                    <input id=submit-button type="submit" value="Filter" />
+                </div>
+            </form>
+        </div>
         {% render_table results_table %}
     </div>
+    <script>
+        let collapsibles = document.getElementsByClassName("collapsible");
+        let i;
+
+        for (i = 0; i < collapsibles.length; i++) {
+            collapsibles[i].addEventListener("click", function() {
+                this.classList.toggle("collapsible-active");
+                let content = this.nextElementSibling;
+                if (content.style.maxHeight){
+                    content.style.maxHeight = null;
+                } else {
+                    content.style.maxHeight = content.scrollHeight + "px";
+                }
+            });
+        }
+    </script>
 {% endblock %}
 


### PR DESCRIPTION
Someone mentioned when the feature was first rolled out that it would be nice to be able to hide the filters to save space.

Collapsed:
![image](https://user-images.githubusercontent.com/13944193/110097211-e441b080-7df2-11eb-9cd4-9a8a98e656e7.png)

Expanded:
![image](https://user-images.githubusercontent.com/13944193/110097292-f58abd00-7df2-11eb-86d3-166cf0b6d09f.png)
