### PR TITLE
sane tagging rules

### DIFF
--- a/aiarena/frontend/templates/match.html
+++ b/aiarena/frontend/templates/match.html
@@ -155,13 +155,24 @@
                 {{ match_tag_form.non_field_errors }}
                 <div class="flex-row-half" style="width: 95%">
                     {{ match_tag_form.tags.errors }}
-                    <label for="{{ match_tag_form.tags.id_for_label }}">Tags(comma separated)</label>
+                    <label for="{{ match_tag_form.tags.id_for_label }}">Tags (comma separated, max 32 chars each, accepts A-Z, a-z, 0-9, space and _)</label>
                     {{ match_tag_form.tags }}
                 </div>
                 <div class="flex-row-short">
                     <input id=submit-button type="submit" value="Save" />
                 </div>
             </form>
+            <script>
+            // Prevent tags from being added if they don't follow the rules
+            $('input').on('beforeItemAdd', function(event) {
+                // check tag contents
+                if (!/^[a-zA-Z0-9 _]+$/.test(event.item) || event.item.length>32) {
+                    console.log(event.item.length)
+                    // set to true to prevent the item getting added
+                    event.cancel = true;
+                }
+            });
+            </script>
         {% endif %}
     </div>
 {% endblock %}

--- a/aiarena/frontend/templates/match.html
+++ b/aiarena/frontend/templates/match.html
@@ -155,7 +155,7 @@
                 {{ match_tag_form.non_field_errors }}
                 <div class="flex-row-half" style="width: 95%">
                     {{ match_tag_form.tags.errors }}
-                    <label for="{{ match_tag_form.tags.id_for_label }}">Tags (comma separated, max 32 chars each, accepts A-Z, a-z, 0-9, space and _)</label>
+                    <label for="{{ match_tag_form.tags.id_for_label }}">Tags (comma separated, max 32 tags at 32 chars each, accepts A-Z, a-z, 0-9, space and _)</label>
                     {{ match_tag_form.tags }}
                 </div>
                 <div class="flex-row-short">
@@ -164,13 +164,18 @@
             </form>
             <script>
             // Prevent tags from being added if they don't follow the rules
-            $('input').on('beforeItemAdd', function(event) {
+            $('input[type=text]').on('beforeItemAdd', function(event) {
                 // check tag contents
-                if (!/^[a-zA-Z0-9 _]+$/.test(event.item) || event.item.length>32) {
+                if (!/^[a-zA-Z0-9 _]+$/.test(event.item)) {
                     console.log(event.item.length)
                     // set to true to prevent the item getting added
                     event.cancel = true;
                 }
+            });
+
+            $('input[type=text]').tagsinput({
+                maxChars: 32,
+                maxTags: 32
             });
             </script>
         {% endif %}

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -1,3 +1,4 @@
+import re
 from datetime import timedelta
 
 from constance import config
@@ -736,7 +737,7 @@ class MatchTagForm(forms.Form):
     def clean_tags(self):
         """convert tags from single string to list"""
         data = self.cleaned_data['tags'].lower().split(",")
-        return [tag.strip() for tag in data if tag]
+        return [re.sub('[^a-zA-Z0-9 _]', '', tag.strip())[:32] for tag in data if tag]
 
 
 class MatchTagFormView(SingleObjectMixin, FormView):

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -737,7 +737,7 @@ class MatchTagForm(forms.Form):
     def clean_tags(self):
         """convert tags from single string to list"""
         data = self.cleaned_data['tags'].lower().split(",")
-        return [re.sub('[^a-zA-Z0-9 _]', '', tag.strip())[:32] for tag in data if tag]
+        return [re.sub('[^a-zA-Z0-9 _]', '', tag.strip())[:32] for tag in data if tag][:32]
 
 
 class MatchTagFormView(SingleObjectMixin, FormView):


### PR DESCRIPTION
Prevents tags from going too wild, plus fixes the page throwing errors when tag is too long.

Limit for number of tags is arbitrary, length of 32 each is due to model.

More work to be done on this branch but wanted to get this through to prevent illegal tags from entering the system in the mean time.