### PR TITLE
Bot match tagging2

### DIFF
--- a/aiarena/core/utils.py
+++ b/aiarena/core/utils.py
@@ -14,9 +14,13 @@ logger = logging.getLogger(__name__)
 
 def parse_tags(tags):
     """convert tags from single string to list if applicable, and then cleans the tags"""
-    if isinstance(tags, str):
-        tags = tags.split(",")
-    return [re.sub(settings.MATCH_TAG_REGEX, '', tag.lower().strip())[:settings.MATCH_TAG_LENGTH_LIMIT] for tag in tags if tag][:settings.MATCH_TAG_PER_MATCH_LIMIT]
+    if tags:
+        if isinstance(tags, str):
+            tags = tags.split(",")
+        tags = [re.sub(settings.MATCH_TAG_REGEX, '', tag.lower().strip())[:settings.MATCH_TAG_LENGTH_LIMIT] for tag in tags if tag]
+        # Remove empty strings that resulted from processing
+        return [tag for tag in tags if tag][:settings.MATCH_TAG_PER_MATCH_LIMIT]
+    return []
 
 
 def calculate_md5(file, block_size=2 ** 20):

--- a/aiarena/core/utils.py
+++ b/aiarena/core/utils.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 def parse_tags(tags):
     """convert tags from single string to list if applicable, and then cleans the tags"""
     if isinstance(tags, str):
-        tags = tags.lower().split(",")
-    return [re.sub('[^a-z0-9 _]', '', tag.strip())[:32] for tag in tags if tag][:32]
+        tags = tags.split(",")
+    return [re.sub(settings.MATCH_TAG_REGEX, '', tag.lower().strip())[:settings.MATCH_TAG_LENGTH_LIMIT] for tag in tags if tag][:settings.MATCH_TAG_PER_MATCH_LIMIT]
 
 
 def calculate_md5(file, block_size=2 ** 20):

--- a/aiarena/core/validators.py
+++ b/aiarena/core/validators.py
@@ -4,6 +4,8 @@ from zipfile import ZipFile, BadZipFile
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 
+from aiarena import settings
+
 
 def validate_not_nan(value):
     if math.isnan(value):
@@ -45,3 +47,8 @@ def validate_bot_zip_file_size(value):
     if value.size > limit * 1024 * 1024:  # convert limit to bytes
         raise ValidationError(f'File too large. Size should not exceed {limit} MB. '
                               f'You can donate to the ladder to increase this limit.')
+
+
+validate_match_tag = RegexValidator(settings.MATCH_TAG_REGEX,
+                                   'Only alphanumeric (a-z, 0-9), space ( ) and underscore (_) '
+                                   'characters are allowed.')

--- a/aiarena/core/validators.py
+++ b/aiarena/core/validators.py
@@ -4,8 +4,6 @@ from zipfile import ZipFile, BadZipFile
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 
-from aiarena import settings
-
 
 def validate_not_nan(value):
     if math.isnan(value):
@@ -47,8 +45,3 @@ def validate_bot_zip_file_size(value):
     if value.size > limit * 1024 * 1024:  # convert limit to bytes
         raise ValidationError(f'File too large. Size should not exceed {limit} MB. '
                               f'You can donate to the ladder to increase this limit.')
-
-
-validate_match_tag = RegexValidator(settings.MATCH_TAG_REGEX,
-                                   'Only alphanumeric (a-z, 0-9), space ( ) and underscore (_) '
-                                   'characters are allowed.')

--- a/aiarena/settings.py
+++ b/aiarena/settings.py
@@ -438,3 +438,8 @@ if ENVIRONMENT_TYPE != EnvironmentType.DEVELOPMENT:
 
 # load this after the env file so if the ELO_K value was overridden, it will be applied properly
 ELO = Elo(ELO_K)
+
+# Match Tag Constants
+MATCH_TAG_REGEX = r'[^a-z0-9 _]'
+MATCH_TAG_LENGTH_LIMIT = 32
+MATCH_TAG_PER_MATCH_LIMIT = 32


### PR DESCRIPTION
AC can now send tags when submitting match results, allowing Bots to automatically tag matches.

No validation is done by django, it will accept no tags or a list of any strings. Validation is manually done after receiving the result and using `aiarena.core.utils.parse_tags` because I assume that we do not want invalid tags to be the cause of result submission failures.

This is only one half of the equation, will still need to update ACs to support this, which could be implementing [issue 2](https://github.com/aiarena/aiarena-client/issues/2) and then reading a json file containing the tags in the `out` folder.