### PR TITLE
Expose tags via match api, filter matchparticipations by tags

### DIFF
--- a/aiarena/api/view_filters.py
+++ b/aiarena/api/view_filters.py
@@ -29,7 +29,7 @@ class TagsFilter(filters.CharFilter):
             try:
                 users = [int(s) for s in users_str.split(',')]
             except ValueError:
-                raise ValidationError("When using pipe separator (\"|\"), Expecting user_id (int) on LHS and tag_name on RHS of separator.")
+                raise ValidationError({"tags":["When using pipe separator (|), Expecting user_id (int) on LHS and tag_name on RHS of separator."]})
             lookup = '%s__%s' % (self.field_name2, self.lookup_expr)
             for v in users:
                 user_query = user_query | Q(**{lookup: v})

--- a/aiarena/api/view_filters.py
+++ b/aiarena/api/view_filters.py
@@ -78,7 +78,6 @@ class MatchParticipationFilter(filters.FilterSet):
     min_avg_step_time = filters.NumberFilter(field_name="avg_step_time", lookup_expr='gte')
     max_avg_step_time = filters.NumberFilter(field_name="avg_step_time", lookup_expr='lte')
     avg_step_time = filters.NumberFilter(field_name="avg_step_time")
-    tags = TagsFilter(field_name="match__tags__tag__name", field_name2="match__tags__user")
 
     class Meta:
         model = MatchParticipation
@@ -126,6 +125,7 @@ class MatchFilter(filters.FilterSet):
     assigned_to = filters.NumberFilter(field_name="assigned_to")
     requested_by = filters.NumberFilter(field_name="requested_by")
     map = filters.NumberFilter(field_name="map")
+    bot = filters.NumberFilter(field_name="matchparticipation__bot")
     tags = TagsFilter(field_name="tags__tag__name", field_name2="tags__user")
     
     class Meta:

--- a/aiarena/api/views.py
+++ b/aiarena/api/views.py
@@ -267,6 +267,7 @@ class MatchTagSerializer(serializers.ModelSerializer):
 class MatchSerializer(serializers.ModelSerializer):
     result = ResultSerializer()
     tags = MatchTagSerializer(many=True)
+
     class Meta:
         model = Match
         fields = match_include_fields + ('result',)

--- a/aiarena/api/views.py
+++ b/aiarena/api/views.py
@@ -9,7 +9,7 @@ from rest_framework.filters import SearchFilter, OrderingFilter
 from rest_framework.reverse import reverse
 from django.db.models import Prefetch
 
-from aiarena.core.models import Match, Result, Bot, Map, User, Round, MatchParticipation, CompetitionParticipation, Competition
+from aiarena.core.models import Match, Result, Bot, Map, User, Round, MatchParticipation, CompetitionParticipation, Competition, Tag, MatchTag
 from aiarena.api.view_filters import BotFilter, MatchParticipationFilter, ResultFilter, MatchFilter
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,8 @@ bot_search_fields = 'id', 'user', 'name', 'created', 'plays_race', 'type', \
                     'game_display_id', 'bot_zip_updated', 'bot_zip_publicly_downloadable', 'bot_data_publicly_downloadable'
 map_include_fields = 'id', 'name', 'file',
 map_filter_fields = 'id', 'name',
-match_include_fields = 'id', 'map', 'created', 'started', 'assigned_to', 'round', 'requested_by',
+matchtag_include_fields = 'user',
+match_include_fields = 'id', 'map', 'created', 'started', 'assigned_to', 'round', 'requested_by', 'tags'
 matchparticipation_include_fields = 'id', 'match', 'participant_number', 'bot', 'starting_elo', 'resultant_elo', \
                                     'elo_change', 'avg_step_time', 'match_log', 'result', 'result_cause',
 matchparticipation_filter_fields = 'id', 'match', 'participant_number', 'bot', 'starting_elo', 'resultant_elo', \
@@ -253,8 +254,19 @@ class ResultViewSet(viewsets.ReadOnlyModelViewSet):
 
 # !ATTENTION! IF YOU CHANGE THE API ANNOUNCE IT TO USERS
 
+class MatchTagSerializer(serializers.ModelSerializer):
+    tag_name = serializers.SerializerMethodField()
+
+    def get_tag_name(self, obj):
+        return obj.tag.name
+
+    class Meta:
+        model = MatchTag
+        fields = matchtag_include_fields + ('tag_name',)
+
 class MatchSerializer(serializers.ModelSerializer):
     result = ResultSerializer()
+    tags = MatchTagSerializer(many=True)
     class Meta:
         model = Match
         fields = match_include_fields + ('result',)


### PR DESCRIPTION
Edit: Removed the stupid rambling I typed out while half asleep

Hi lladdy,

I would like to get feedback because the way I did this is API likely not best practice and not well planned out. Let me know if you have any suggestions.

I've added tags to the match API so that when queried we are able to see all tags on the given match:
* `/api/matches?tags=abcd`
* result:
![image](https://user-images.githubusercontent.com/13944193/123516246-81945d80-d6de-11eb-9340-ddd92e1ac514.png)

I thought it might be useful to have the ability to filter by person who created the tag as well but I couldn't figure out how to do it in a non-hacky way that would be usable via swagger so I just ended up using the pipe separator to denote users on left and tags on right:
* `/api/matches?tags=1,2|abcd,1234` will filter for matches containing both tags `abcd` AND `1234` by user `1` OR `2`
* `/api/matches?tags=1|` will filter for matches containing any tags by user `1`