### PR TITLE
Targeted truncation of long bot names, shortened datetime on bot page

### DIFF
--- a/aiarena/core/models/bot.py
+++ b/aiarena/core/models/bot.py
@@ -182,6 +182,12 @@ class Bot(models.Model, LockableModelMixin):
         return mark_safe(f'<a href="{self.get_absolute_url}">{escape(self.__str__())}</a>')
 
     @cached_property
+    def as_truncated_html_link(self):
+        name = escape(self.__str__())
+        limit = 20
+        return mark_safe(f'<a href="{self.get_absolute_url}">{(name[:limit] + "...") if len(name) > limit + 3 else name}</a>')
+
+    @cached_property
     def as_html_link_with_race(self):
         return mark_safe(f'<a href="{self.get_absolute_url}">{escape(self.__str__())} ({self.plays_race})</a>')
 

--- a/aiarena/frontend/templates/arenaclient.html
+++ b/aiarena/frontend/templates/arenaclient.html
@@ -38,12 +38,12 @@
                     <td>{{ match.as_html_link }}</td>
                     {% for p in match.participants %}
                         {% if p.participant_number == 1 %}
-                            <td>{{ p.bot.as_html_link }}</td>
+                            <td>{{ p.bot.as_truncated_html_link }}</td>
                         {% endif %}
                     {% endfor %}
                     {% for p in match.participants %}
                         {% if p.participant_number == 2 %}
-                            <td>{{ p.bot.as_html_link }}</td>
+                            <td>{{ p.bot.as_truncated_html_link }}</td>
                         {% endif %}
                     {% endfor %}
                     <td>{{ match.map }}</td>
@@ -83,9 +83,9 @@
                         {% if p.participant_number == 1 %}
                             <td style="padding-right: 0">
                                 {% if result.winner == p.bot %}
-                                    <strong>[{{ p.bot.as_html_link }}]</strong>
+                                    <strong>[{{ p.bot.as_truncated_html_link }}]</strong>
                                 {% else %}
-                                    {{ p.bot.as_html_link }}
+                                    {{ p.bot.as_truncated_html_link }}
                                 {% endif %}
                             </td>
 

--- a/aiarena/frontend/templates/bot_competition_stats.html
+++ b/aiarena/frontend/templates/bot_competition_stats.html
@@ -108,7 +108,7 @@
             {% if competition_bot_matchups.count > 0 %}
                 {% for bot_matchup in competition_bot_matchups %}
                     <tr style="text-align: right">
-                        <td style="text-align: right">{{ bot_matchup.opponent.bot.as_html_link }}</td>
+                        <td style="text-align: right">{{ bot_matchup.opponent.bot.as_truncated_html_link }}</td>
                         <td class="mono"
                             style="text-align: left">{{ bot_matchup.opponent.bot.get_plays_race_display }}</td>
                         <td class="mono">{{ bot_matchup.match_count }}</td>

--- a/aiarena/frontend/templates/index.html
+++ b/aiarena/frontend/templates/index.html
@@ -108,7 +108,7 @@
                                                     <div class="bot-icon-{{ participant.bot.user.patreon_level }}" style="padding-right: 0; float: right" title="{{ participant.bot.user.get_patreon_level_display }} supporter"></div>
                                                 {% endif %}
                                             </td>
-                                            <td>{{ participant.bot.as_html_link }}</td>
+                                            <td>{{ participant.bot.as_truncated_html_link }}</td>
                                             <td>
                                                 {{ participant.elo }}
                                                 {% bot_competition_trend participant.bot item.competition as trend %}
@@ -161,10 +161,10 @@
                 {# newly created bots have same update time as its creation time #}
                 {% if event.is_created_event %}
                     <td nowrap>{{ event.bot_zip_updated|naturaltime|shorten_naturaltime }}</td>
-                    <td style="text-align: left">{{ event.user.as_html_link }} uploaded a new bot: {{ event.as_html_link }}.</td>
+                    <td style="text-align: left">{{ event.user.as_html_link }} uploaded a new bot: {{ event.as_truncated_html_link }}.</td>
                 {% else %}
                     <td nowrap>{{ event.bot_zip_updated|naturaltime|shorten_naturaltime }}</td>
-                    <td style="text-align: left">Bot {{ event.as_html_link }} was updated.</td>
+                    <td style="text-align: left">Bot {{ event.as_truncated_html_link }} was updated.</td>
                 {% endif %}
                 </tr>
             {% endfor %}

--- a/aiarena/frontend/templates/match_queue.html
+++ b/aiarena/frontend/templates/match_queue.html
@@ -23,12 +23,12 @@
                             <td>{{ match.as_html_link }}</td>
                             {% for p in match.participants %}
                                 {% if p.participant_number == 1 %}
-                                    <td>{{ p.bot.as_html_link }}</td>
+                                    <td>{{ p.bot.as_truncated_html_link }}</td>
                                 {% endif %}
                             {% endfor %}
                             {% for p in match.participants %}
                                 {% if p.participant_number == 2 %}
-                                    <td>{{ p.bot.as_html_link }}</td>
+                                    <td>{{ p.bot.as_truncated_html_link }}</td>
                                 {% endif %}
                             {% endfor %}
                             <td>{{ match.map }}</td>
@@ -68,12 +68,12 @@
                             <td>{{ match.as_html_link }}</td>
                             {% for p in match.participants %}
                                 {% if p.participant_number == 1 %}
-                                    <td>{{ p.bot.as_html_link }}</td>
+                                    <td>{{ p.bot.as_truncated_html_link }}</td>
                                 {% endif %}
                             {% endfor %}
                             {% for p in match.participants %}
                                 {% if p.participant_number == 2 %}
-                                    <td>{{ p.bot.as_html_link }}</td>
+                                    <td>{{ p.bot.as_truncated_html_link }}</td>
                                 {% endif %}
                             {% endfor %}
                             <td>{{ match.map }}</td>

--- a/aiarena/frontend/templates/profile.html
+++ b/aiarena/frontend/templates/profile.html
@@ -75,7 +75,7 @@
         </thead>
         {% for bot in bot_list %}
             <tr>
-                <td>{{ bot.as_html_link }}</td>
+                <td>{{ bot.as_truncated_html_link }}</td>
                 <td>{{ bot.get_plays_race_display }}</td>
                 <td>{{ bot.type }}</td>
                 <td><a href="{{ bot.bot_zip.url }}">Download</a></td>
@@ -117,12 +117,12 @@
                         {% endif %}
                         {% for p in match.participants %}
                             {% if p.participant_number == 1 %}
-                                <td>{{ p.bot.as_html_link }}</td>
+                                <td>{{ p.bot.as_truncated_html_link }}</td>
                             {% endif %}
                         {% endfor %}
                         {% for p in match.participants %}
                             {% if p.participant_number == 2 %}
-                                <td>{{ p.bot.as_html_link }}</td>
+                                <td>{{ p.bot.as_truncated_html_link }}</td>
                             {% endif %}
                         {% endfor %}
                         <td>{{ match.map }}</td>

--- a/aiarena/frontend/templates/results.html
+++ b/aiarena/frontend/templates/results.html
@@ -26,9 +26,9 @@
                     {% if p.participant_number == 1 %}
                         <td style="padding-right: 0">
                             {% if result.winner == p.bot %}
-                                <strong>[{{ p.bot.as_html_link }}]</strong>
+                                <strong>[{{ p.bot.as_truncated_html_link }}]</strong>
                             {% else %}
-                                {{ p.bot.as_html_link }}
+                                {{ p.bot.as_truncated_html_link }}
                             {% endif %}
                         </td>
 
@@ -57,9 +57,9 @@
                     {% if p.participant_number == 2 %}
                         <td style="padding-right: 0">
                             {% if result.winner == p.bot %}
-                                <strong>[{{ p.bot.as_html_link }}]</strong>
+                                <strong>[{{ p.bot.as_truncated_html_link }}]</strong>
                             {% else %}
-                                {{ p.bot.as_html_link }}
+                                {{ p.bot.as_truncated_html_link }}
                             {% endif %}
                         </td>
 

--- a/aiarena/frontend/templates/round.html
+++ b/aiarena/frontend/templates/round.html
@@ -35,10 +35,10 @@
         <td><strong>Assigned to</strong></td>
     </thead>
     {% for match in round.match_set.all %}
-        <tr>
+        <tr> 
             <td>{{ match.as_html_link }}</td>
-            <td>{{ match.participant1.bot.as_html_link }}</td>
-            <td>{{ match.participant2.bot.as_html_link }}</td>
+            <td>{{ match.participant1.bot.as_truncated_html_link }}</td>
+            <td>{{ match.participant2.bot.as_truncated_html_link }}</td>
             {% if match.started %}
                 <td>{{ match.started|date:"d. N Y - H:i:s" }}</td>
             {% else %}

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -234,7 +234,7 @@ class BotResultTable(tables.Table):
     # Settings for individual columns
     # match could be a LinkColumn, but used ".as_html_link" since that is being used elsewhere.
     match = tables.Column(verbose_name="ID")
-    created = tables.DateTimeColumn(format="d. N Y - H:i:s", verbose_name="Date")
+    created = tables.DateTimeColumn(format="d N y, H:i", verbose_name="Date")
     result_cause = tables.Column(verbose_name="Cause")
     elo_change = tables.Column(verbose_name="+/-")
     avg_step_time = tables.Column(
@@ -266,7 +266,7 @@ class BotResultTable(tables.Table):
         return value.as_html_link
 
     def render_opponent(self, value):
-        return value.bot.as_html_link
+        return value.bot.as_truncated_html_link
 
     def render_elo_change(self, record, value):
         return "--" if record.match.requested_by else format_elo_change(value)


### PR DESCRIPTION
Truncate long bot names anywhere that it seems it will cause formatting to break.

![image](https://user-images.githubusercontent.com/13944193/133620473-2762f1ee-f7ff-4517-b313-e570f3973b57.png)
