### PR TITLE
Fix hover link color in bot bio

### DIFF
--- a/aiarena/frontend/static/style.css
+++ b/aiarena/frontend/static/style.css
@@ -241,6 +241,14 @@ a:hover {
     text-align: left;
 }
 
+#bot_bio tr:hover a {
+    color: #86c232;
+}
+
+#bot_bio tr:hover a:hover {
+    color: #ffffff;
+}
+
 #bot_wiki_article {
     padding: 0 10px 0 10px;
 }


### PR DESCRIPTION
Without this, when you hover over the bot bio, all links in it are highlighted.