### PR TITLE
Added associated maps in competition page

### DIFF
--- a/aiarena/frontend/templates/competition.html
+++ b/aiarena/frontend/templates/competition.html
@@ -45,6 +45,21 @@
                     </tr>
                     </tbody>
                 </table>
+                <br />
+                <table summary="Table containing associated maps">
+                    <thead>
+                    <tr>
+                        <td><strong>Maps</strong></td>
+                    </tr>
+                    </thead>
+                    <tbody>
+                        {% for map_name in map_names %}
+                            <tr>
+                                <td>{{ map_name }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
             <div id="competition_description">
                 <table summary="Table containing the competition description">

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -35,7 +35,7 @@ from aiarena.core.api.maps import Maps
 from aiarena.core.d_utils import filter_tags
 from aiarena.core.models import Bot, Result, User, Round, Match, MatchParticipation, CompetitionParticipation, \
     Competition, Map, \
-    ArenaClient, News, MapPool, MatchTag, Tag
+    ArenaClient, News, MapPool, MatchTag, Tag, competition
 from aiarena.core.models import Trophy
 from aiarena.core.models.bot_race import BotRace
 from aiarena.core.models.relative_result import RelativeResult
@@ -947,6 +947,12 @@ class CompetitionDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(CompetitionDetail, self).get_context_data(**kwargs)
+
+        maps = self.object.maps.all()
+        map_names = []
+        for map in maps:
+            map_names.append(map.name)
+        context['map_names'] = map_names
 
         rounds = Round.objects.filter(competition_id=self.object.id).order_by('-id')
         page = self.request.GET.get('page', 1)

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -35,7 +35,7 @@ from aiarena.core.api.maps import Maps
 from aiarena.core.d_utils import filter_tags
 from aiarena.core.models import Bot, Result, User, Round, Match, MatchParticipation, CompetitionParticipation, \
     Competition, Map, \
-    ArenaClient, News, MapPool, MatchTag, Tag, competition
+    ArenaClient, News, MapPool, MatchTag, Tag
 from aiarena.core.models import Trophy
 from aiarena.core.models.bot_race import BotRace
 from aiarena.core.models.relative_result import RelativeResult


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46042091/181444066-da0c3b1d-e5c2-4d1c-9c78-e1321ff423ad.png)

Listed associated maps on the competition page as stated in #422.