### PR TITLE
Ac api restrict bot download

### DIFF
--- a/aiarena/core/models/bot.py
+++ b/aiarena/core/models/bot.py
@@ -214,10 +214,26 @@ class Bot(models.Model, LockableModelMixin):
             return 'run.py'
 
     def can_download_bot_zip(self, user):
-        return self.user == user or self.bot_zip_publicly_downloadable or user.is_staff
+        """
+        Only allow download of bot_zip if any of:
+        - This user owns the bot
+        - The bot_zip is publicly downloadable
+        - This user is a staff user
+        - This user is a trusted arenaclient
+        """
+        return self.user == user or self.bot_zip_publicly_downloadable or user.is_staff \
+               or (user.is_arenaclient and user.arenaclient.trusted)
 
     def can_download_bot_data(self, user):
-        return self.user == user or self.bot_data_publicly_downloadable or user.is_staff
+        """
+        Only allow download of bot_data if any of:
+        - This user owns the bot
+        - The bot_data is publicly downloadable
+        - This user is a staff user
+        - This user is a trusted arenaclient
+        """
+        return self.user == user or self.bot_data_publicly_downloadable or user.is_staff \
+               or (user.is_arenaclient and user.arenaclient.trusted)
 
     # for purpose of distinquish news in activity feed
     def get_model_name(self):

--- a/aiarena/core/models/match.py
+++ b/aiarena/core/models/match.py
@@ -66,7 +66,10 @@ class Match(models.Model, LockableModelMixin, RandomManagerMixin):
             # NOTE: This could be done when getting a match to play.
             # Allowing the match to be played on a untrusted client if the user allows the download after requesting a match.
             if not require_trusted_arenaclient:
-                require_trusted_arenaclient = not bot1.bot_zip_publicly_downloadable or not bot2.bot_zip_publicly_downloadable
+                require_trusted_arenaclient = not bot1.bot_zip_publicly_downloadable \
+                                              or not bot2.bot_zip_publicly_downloadable \
+                                              or not bot1.bot_data_publicly_downloadable \
+                                              or not bot2.bot_data_publicly_downloadable
 
             match = Match.objects.create(map=map, round=round, requested_by=requested_by, require_trusted_arenaclient=require_trusted_arenaclient)
             # create match participations


### PR DESCRIPTION
- Restrict download of bot zip and data to only trusted ACs
- Require a trusted AC when bot data is private.