### PR TITLE
remove tests from master branch ci

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,9 +2,9 @@ name: Django CI
 
 on:
   push:
-    branches: [ master, staging ]
+    branches: [ staging ]
   pull_request:
-    branches: [ master, staging ]
+    branches: [ staging ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR removes the running of tests from the master branch - all the tests get run on the staging branch before we merge to master anyway.