### PR TITLE
feat: Remove trending indicator for finalized competitions

### DIFF
--- a/aiarena/frontend/templates/competition.html
+++ b/aiarena/frontend/templates/competition.html
@@ -120,32 +120,36 @@
                                 <td>No stats</td>
                             {% endif %}
                             <td>
-                                {% if participant.in_placements %}
-                                    Placements
-                                {% else %}
+                                {% if competition.competition_finalized %}
                                     {{ participant.elo }}
-                                    {% bot_competition_trend participant.bot competition as trend %}
-                                        {% if trend > 40 %}
-                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; transform: rotate(-90deg);" title="ELO gained {{trend}} in the last 30 games">
-                                                trending_flat
-                                            </em>
-                                        {% elif trend < -40 %}
-                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; transform: rotate(90deg);" title="ELO changed {{trend}} in the last 30 games">
-                                                trending_flat
-                                            </em>
-                                        {% elif trend > 15 %}
-                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;" title="ELO gained {{trend}} in the last 30 games">
-                                                trending_up
-                                            </em>
-                                        {% elif trend < -15 %}
-                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;" title="ELO changed {{trend}} in the last 30 games">
-                                                trending_down
-                                            </em>
-                                        {% else %}
-                                            <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;" title="ELO changed {{trend}} in the last 30 games">
-                                                trending_flat
-                                            </em>
-                                        {% endif %}
+                                {% else %}
+                                    {% if participant.in_placements %}
+                                        Placements
+                                    {% else %}
+                                        {{ participant.elo }}
+                                        {% bot_competition_trend participant.bot competition as trend %}
+                                            {% if trend > 40 %}
+                                                <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; transform: rotate(-90deg);" title="ELO gained {{trend}} in the last 30 games">
+                                                    trending_flat
+                                                </em>
+                                            {% elif trend < -40 %}
+                                                <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em; transform: rotate(90deg);" title="ELO changed {{trend}} in the last 30 games">
+                                                    trending_flat
+                                                </em>
+                                            {% elif trend > 15 %}
+                                                <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;" title="ELO gained {{trend}} in the last 30 games">
+                                                    trending_up
+                                                </em>
+                                            {% elif trend < -15 %}
+                                                <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;" title="ELO changed {{trend}} in the last 30 games">
+                                                    trending_down
+                                                </em>
+                                            {% else %}
+                                                <em class="material-icons" style="padding: 0; margin:0; vertical-align: -0.3em;" title="ELO changed {{trend}} in the last 30 games">
+                                                    trending_flat
+                                                </em>
+                                            {% endif %}
+                                    {% endif %}
                                 {% endif %}
                             </td>
                             <td><a href="{% url 'bot_competition_stats' participant.id participant.slug %}">Stats</a></td>


### PR DESCRIPTION
This PR removes the trending icon from the ELO rankings on finalized competitions.