### PR TITLE
Fix trending elo exception

### DIFF
--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -467,18 +467,6 @@ class BotCompetitionStatsDetail(DetailView):
         return context
 
 
-class BotCompetitionStatsEloUpdatePlot(DetailView):
-    model = CompetitionParticipation
-    template_name = 'bot_competition_stats.html'
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['competition_bot_matchups'] = self.object.competition_matchup_stats.filter(
-            opponent__competition=context['competitionparticipation'].competition).order_by('-win_perc').distinct()
-        context['updated'] = context['competition_bot_matchups'][0].updated if context['competition_bot_matchups'] else "Never"
-        return context
-
-
 class BotCompetitionStatsEloGraphUpdatePlot(PrivateStorageDetailView):
     model = CompetitionParticipation
     model_file_field = 'elo_graph_update_plot'


### PR DESCRIPTION
This PR avoids an exception that occurs when `sql_with_params()` is called on an empty result set