### PR TITLE
Add ability to cancel all active matches

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,7 +12,23 @@ jobs:
     - name: Deploy Staging
       uses: garygrossgarten/github-action-ssh@release
       with:
-        command: cd /home/aiarena/ai-arena/ && git checkout staging && git pull origin staging && git submodule update --init --recursive && source venv/bin/activate && python3 ./pip/pip-install.py && python3 manage.py collectstatic --noinput && /home/aiarena/refreshdb.sh && python3 manage.py repairbothashes && python3 manage.py migrate && python3 manage.py purgesensitivedata && sudo apachectl graceful && pw=`cat ~/.redis` && redis-cli -a "$pw" -n 1 FLUSHDB && exit
+        command: >
+          cd /home/aiarena/ai-arena/ 
+          && git checkout staging 
+          && git pull origin staging 
+          && git submodule update --init --recursive 
+          && source venv/bin/activate 
+          && python3 ./pip/pip-install.py 
+          && python3 manage.py collectstatic --noinput 
+          && /home/aiarena/refreshdb.sh 
+          && python3 manage.py migrate 
+          && python3 manage.py purgesensitivedata 
+          && python3 manage.py repairbothashes 
+          && python3 manage.py cancelmatches --active 
+          && sudo apachectl graceful 
+          && pw=`cat ~/.redis` 
+          && redis-cli -a "$pw" -n 1 FLUSHDB 
+          && exit
         host: ${{ secrets.STAGING_HOST }}
         port: ${{ secrets.STAGING_PORT }}
         username: ${{ secrets.STAGING_USERNAME }}

--- a/aiarena/core/api/matches.py
+++ b/aiarena/core/api/matches.py
@@ -22,6 +22,19 @@ logger = logging.getLogger(__name__)
 
 class Matches:
     @staticmethod
+    def cancel(match_id):
+        try:
+            with transaction.atomic():
+                match = Match.objects.select_for_update().get(pk=match_id)
+                result = match.cancel(None)
+                if result == Match.CancelResult.MATCH_DOES_NOT_EXIST:  # should basically not happen, but just in case
+                    raise Exception('Match "%s" does not exist' % match_id)
+                elif result == Match.CancelResult.RESULT_ALREADY_EXISTS:
+                    raise Exception('A result already exists for match "%s"' % match_id)
+        except Match.DoesNotExist:
+            raise Exception('Match "%s" does not exist' % match_id)
+
+    @staticmethod
     def request_match(user, bot, opponent, map: Map=None, game_mode: GameMode=None):
         # if map is none, a game mode must be supplied and a random map gets chosen
         if map is None:


### PR DESCRIPTION
This PR adds an option to the `cancelmatches` command to specify that all active (started but not finished) matches should be cancelled. 