### PR TITLE
Add current production settings to prod.py

### DIFF
--- a/aiarena/settings/prod.py
+++ b/aiarena/settings/prod.py
@@ -17,13 +17,59 @@ SECRET_KEY = os.environ.get("SECRET_KEY", None)
 if SECRET_KEY is None:
     raise Exception("You must set the SECRET_KEY to something secure before running in production or staging.")
 
-ALLOWED_HOSTS = ["aiarena-test.net", "aiarena.net", "*"]
+ALLOWED_HOSTS = ["aiarena-test.net", "aiarena.net", "sc2ai.net", "www.sc2ai.net"]
 SECURE_SSL_REDIRECT = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-#################################
+################################################################################
+# Password validation                                                          #
+# https://docs.djangoproject.com/en/2.1/ref/settings/#auth-password-validators #
+################################################################################
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
+]
+
+#######################
+# Cache Configuration #
+#######################
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "django-cache-default",
+    },
+    "select2": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "django-cache-select2",
+    },
+}
+
+##################
+# Email Settings #
+##################
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.environ.get("EMAIL_HOST")
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS")
+EMAIL_PORT = os.environ.get("EMAIL_PORT")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+
+##########################################################
 # Django Storages & django-private-storage configuration #
-#################################
+##########################################################
 
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 PRIVATE_STORAGE_CLASS = "private_storage.storage.s3boto3.PrivateS3BotoStorage"


### PR DESCRIPTION
This PR adds the current settings from production to the prod.py file.

Note the addition of the database as cache settings - we might want to change these to redis, given that we have an instance. 