### PR TITLE
Tweak maintenance message to fix spacing in AI Arena name

### DIFF
--- a/aiarena/frontend/templates/maintenance.html
+++ b/aiarena/frontend/templates/maintenance.html
@@ -4,10 +4,10 @@
 {% block sidebar %}{% endblock %}
 
 {% block content %}
-    <div class="divider"><span></span><span><h2>AIArena is currently under maintenance</h2></span><span></span></div>
+    <div class="divider"><span></span><span><h2>AI Arena is currently under maintenance</h2></span><span></span></div>
     <div id="inner_content">
         <center>
-            AIArena is currently under scheduled technical maintenance. <br />
+            AI Arena is currently under scheduled technical maintenance. <br />
             We are upgrading our systems to improve site performance and reliability.<br />
             Please check back in a while. It shouldn't take longer than 60 minutes.
         </center>

--- a/aiarena/frontend/templates/maintenance.html
+++ b/aiarena/frontend/templates/maintenance.html
@@ -9,7 +9,7 @@
         <center>
             AI Arena is currently under scheduled technical maintenance. <br />
             We are upgrading our systems to improve site performance and reliability.<br />
-            Please check back in a while. It shouldn't take longer than 60 minutes.
+            Please check back in a while.
         </center>
     </div>
 {% endblock %}


### PR DESCRIPTION
This PR:
- Fixes the spacing in the "AI Arena" name
- Makes the message slightly different so it's easier to tell when we're on the new site.