### PR TITLE
Use advisory lock on stats gen in place of competition locking,…

### DIFF
--- a/.run/Tests.run.xml
+++ b/.run/Tests.run.xml
@@ -1,14 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Tests" type="DjangoTestsConfigurationType">
     <module name="aiarena-web" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
-      <env name="DJANGO_SETTINGS_MODULE" value="aiarena.settings" />
       <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="DJANGO_SETTINGS_MODULE" value="aiarena.settings" />
       <env name="DJANGO_ENVIRONMENT" value="DEVELOPMENT" />
     </envs>
-    <option name="SDK_HOME" value="C:\Users\ipete\PycharmProjects\aiarena-web\venv\Scripts\python.exe" />
+    <option name="SDK_HOME" value="$PROJECT_DIR$/venv/bin/python" />
     <option name="SDK_NAME" value="Python 3.10 (aiarena-web)" />
     <option name="WORKING_DIRECTORY" value="" />
     <option name="IS_MODULE_SDK" value="false" />

--- a/aiarena/core/api/bot_statistics.py
+++ b/aiarena/core/api/bot_statistics.py
@@ -23,7 +23,7 @@ class BotStatistics:
         This can be done much quicker that regenerating a bot's entire set of stats"""
 
         if result.type not in BotStatistics._ignored_result_types and bot.competition.indepth_bot_statistics_enabled:
-            with advisory_lock(f"stats_lock_{bot.id}") as acquired:
+            with advisory_lock(f"stats_lock_competitionparticipation_{bot.id}") as acquired:
                 if not acquired:
                     raise Exception(
                         "Could not acquire lock on bot statistics for competition participation " + str(bot.id)

--- a/aiarena/core/api/bot_statistics.py
+++ b/aiarena/core/api/bot_statistics.py
@@ -36,9 +36,9 @@ class BotStatistics:
     def recalculate_stats(sp: CompetitionParticipation):
         """This method entirely recalculates a bot's set of stats."""
 
-        with advisory_lock(f"stats_lock_{sp.id}") as acquired:
+        with advisory_lock(f"stats_lock_competitionparticipation_{sp.id}") as acquired:
             if not acquired:
-                raise Exception("Could not acquire lock on bot statistics for competition participation " + str(sp.id))
+                raise Exception(f"Could not acquire lock on bot statistics for competition participation  {str(sp.id)}")
 
             BotStatistics._recalculate_global_statistics(sp)
 
@@ -154,7 +154,7 @@ class BotStatistics:
             with connection.cursor() as cursor:
                 match_count = BotStatistics._calculate_matchup_count(cursor, competition_participation, sp)
                 if match_count > 0:
-                    matchup_stats = CompetitionBotMatchupStats.objects.select_for_update().get_or_create(
+                    matchup_stats = CompetitionBotMatchupStats.objects.get_or_create(
                         bot=sp, opponent=competition_participation
                     )[0]
 
@@ -183,9 +183,7 @@ class BotStatistics:
 
     @staticmethod
     def _update_matchup_stats(bot: CompetitionParticipation, opponent: CompetitionParticipation, result: Result):
-        matchup_stats = CompetitionBotMatchupStats.objects.select_for_update().get_or_create(
-            bot=bot, opponent=opponent
-        )[0]
+        matchup_stats = CompetitionBotMatchupStats.objects.get_or_create(bot=bot, opponent=opponent)[0]
 
         matchup_stats.match_count += 1
 

--- a/aiarena/core/management/commands/generatestats.py
+++ b/aiarena/core/management/commands/generatestats.py
@@ -1,6 +1,8 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
+from django_pglocks import advisory_lock
+
 from aiarena.core.api.bot_statistics import BotStatistics
 from aiarena.core.models import Competition, CompetitionParticipation
 
@@ -47,18 +49,33 @@ class Command(BaseCommand):
             # only process competitions this bot was present for.
             competitions = competitions.filter(participations__bot_id=bot_id)
 
-        self.stdout.write(f"looping   {len(competitions)} Competitions")
+        self.stdout.write(f"looping {len(competitions)} Competitions")
         for competition in competitions:
-            with transaction.atomic():
-                competition.lock_me()
-                if not competition.statistics_finalized:
-                    if finalize:
-                        competition.statistics_finalized = True
-                        competition.save()
-                    for sp in CompetitionParticipation.objects.filter(competition_id=competition.id):
-                        self.stdout.write(f"Generating current competition stats for bot {sp.bot_id}...")
-                        BotStatistics.recalculate_stats(sp)
-                else:
-                    self.stdout.write(f"WARNING: Skipping competition {competition.id} - stats already finalized.")
+            if finalize:
+                self.stdout.write(f"Finalizing stats for competition {competition.id}...")
+                with transaction.atomic():
+                    # This lock will be held for a long time.
+                    # This is considered acceptable as we only finalize old competitions,
+                    # so no matches should be running. We also need all bot stats data to be successfully
+                    # regenerated before we can finalize the competition, else it could end up finalized in a corrupted
+                    # state.
+                    competition.lock_me()
+                    self._run_generate_stats(competition, finalize=True)
+            else:
+                self._run_generate_stats(competition)
 
         self.stdout.write("Done")
+
+    def _run_generate_stats(self, competition, finalize=False):
+        if not competition.statistics_finalized:
+            if finalize:
+                competition.statistics_finalized = True
+                competition.save()
+            with advisory_lock(f"stats_lock_competition_{competition.id}") as acquired:
+                if not acquired:
+                    raise Exception(f"Could not acquire lock on bot statistics for competition {str(competition.id)}")
+                for sp in CompetitionParticipation.objects.filter(competition_id=competition.id):
+                    self.stdout.write(f"Generating current competition stats for bot {sp.bot_id}...")
+                    BotStatistics.recalculate_stats(sp)
+        else:
+            self.stdout.write(f"WARNING: Skipping competition {competition.id} - stats already finalized.")


### PR DESCRIPTION
… unless finalizing

This PR aims to reduce load created by the stats gen by removing locking unless it's absolutely necessary.