### PR TITLE
404 on out of range pagination in AuthorDetail view

### DIFF
--- a/aiarena/frontend/tests.py
+++ b/aiarena/frontend/tests.py
@@ -103,6 +103,10 @@ class PageRenderTestCase(FullDataSetMixin, TransactionTestCase):
         response = self.client.get(f"/authors/{self.regularUser1.id}/")
         self.assertEqual(response.status_code, 200)
 
+        # author - test out of range paging 404
+        response = self.client.get(f"/authors/{self.regularUser1.id}/?page=999")
+        self.assertEqual(response.status_code, 404)
+
         # match
         response = self.client.get(f"/matches/{Match.objects.all()[0].id}/")
         self.assertEqual(response.status_code, 200)

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -742,7 +742,7 @@ class AuthorDetail(DetailView):
         except PageNotAnInteger:
             results = paginator.page(1)
         except EmptyPage:
-            results = paginator.page(paginator.num_pages)
+            raise Http404("Page is out of range.")
 
         return results, restrict_page_range(paginator.num_pages, results.number)
 

--- a/aiarena/frontend/views.py
+++ b/aiarena/frontend/views.py
@@ -731,7 +731,7 @@ class AuthorList(ListView):
 class AuthorDetail(DetailView):
     queryset = User.objects.filter(is_active=1, type="WEBSITE_USER")
     template_name = "author.html"
-    context_object_name = "author"  # change the context name to avoid overriding the current user oontext object
+    context_object_name = "author"  # change the context name to avoid overriding the current user context object
 
     def _paginate_query(self, results_queryset):
         page_size = 10


### PR DESCRIPTION
This is a temporary quick fix due to this:
https://ai-arena.sentry.io/issues/4736455387/?project=4506077370253312&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=1

Specifically an instance where DotBot requested page 92 of an author who had only 6 pages of results available.
The aim is to stop old pagination numbers working so bots will know said requested page is no longer available and stop requesting it.

A more permanent fix in future will be to implement this for all pages that utilize pagination.