### PR TITLE
Fix criteria for starting matches

### DIFF
--- a/aiarena/core/services/internal/match_starter.py
+++ b/aiarena/core/services/internal/match_starter.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class MatchStarter:
     """
-    Responsible for starting a given competition match, including all necessary checks.
+    Responsible for starting a given match, including all necessary checks.
     """
 
     @staticmethod

--- a/aiarena/core/services/internal/match_starter.py
+++ b/aiarena/core/services/internal/match_starter.py
@@ -29,7 +29,7 @@ class MatchStarter:
             return False
 
         # Avoid starting a match when a participant is not available
-        allow_parallel_run = Q(use_bot_data=False) | Q(update_bot_data=False)
+        allow_parallel_run = Q(use_bot_data=False)
         not_in_another_match = ~Exists(
             MatchParticipation.objects.exclude(
                 match_id=match.id,

--- a/aiarena/core/tests/services/internal/test_match_starter.py
+++ b/aiarena/core/tests/services/internal/test_match_starter.py
@@ -187,6 +187,34 @@ class LadderMatchStarterTests(TestCase):
             ]
         )
 
+    def test_match_fails_to_start_in_parallel_when_bot_data_was_updateable_but_now_isnt(self):
+        """
+        Tests that a match fails to start in parallel with another match when a match participant
+            had bot data enabled for updates but updates are now disabled.
+            If this didn't fail, then the new match could be played with old data, which wouldn't be a huge issue, but
+            blocking that situation seems more elegant.
+        """
+        self.start_matches_and_assert_result(
+            test_match_definitions=[
+                {
+                    # Match 1
+                    "expect_success": True,
+                    "use_bot_data_for_participant1": True,
+                    "use_bot_data_for_participant2": True,
+                    "update_bot_data_for_participant1": True,
+                    "update_bot_data_for_participant2": False,
+                },
+                {
+                    # Match 2
+                    "expect_success": False,
+                    "use_bot_data_for_participant1": True,
+                    "use_bot_data_for_participant2": True,
+                    "update_bot_data_for_participant1": False,
+                    "update_bot_data_for_participant2": False,
+                },
+            ]
+        )
+
     def test_match_starts_successfully_in_parallel_when_bot_data_wasnt_updateable_but_now_is(self):
         """
         Tests that a match starts successfully in parallel with another match when a match participant
@@ -264,12 +292,6 @@ class LadderMatchStarterTests(TestCase):
                 },
             ]
         )
-
-    """
-    BONUS TEST:
-    If this test passes it's great, but if it fails, it only means that the system is more restrictive than it needs to be.
-    It's fine to leave it this way and remove this test.
-    """
 
     def test_match_starts_successfully_in_parallel_when_bot_data_was_previously_updateable_but_now_not_in_use(self):
         """


### PR DESCRIPTION
This PR fixes the criteria for starting matches while a currently running match is updating bot data.