### PR TITLE
--About page --

### DIFF
--- a/frontend/packages/web/src/app/(unprotected_pages)/about/page.tsx
+++ b/frontend/packages/web/src/app/(unprotected_pages)/about/page.tsx
@@ -2,35 +2,36 @@
 import React from "react";
 import { graphql } from "relay-runtime";
 import {useLazyLoadQuery} from "react-relay";
+import { pageAboutQuery } from "./__generated__/pageAboutQuery.graphql";
 
 
-export function nodes(connection: { edges: any; }) {
-  const edges = connection ? connection.edges || connection : [];
-  // @ts-ignore
-  return edges.map((n) => n.node);
+// Utility to extract nodes safely from the connection
+export function nodes<T>(connection: { edges: ReadonlyArray<{ node: T | null | undefined } | null | undefined> } | null | undefined): T[] {
+  if (!connection || !connection.edges) return [];
+  return connection.edges
+    .filter((edge): edge is { node: T } => edge !== null && edge !== undefined && edge.node !== null && edge.node !== undefined)
+    .map((edge) => edge.node);
 }
 
-
 function Page() {
-  const data = useLazyLoadQuery(
-    graphql`
-      query pageAboutQuery {
-        news(last: 5) {
-          edges {
-            node {
-              id
-              title
-              text
+  const data = useLazyLoadQuery<pageAboutQuery>(
+      graphql`
+        query pageAboutQuery {
+          news(last: 5) {
+            edges {
+              node {
+                id
+                title
+                text
+              }
             }
           }
         }
-      }
-    `,
-    {},
+      `,
+      {},
   );
-
   return (
-    <>
+      <>
       {nodes(data.news).map((newsItem) => <div key={newsItem.id}>{newsItem.title}</div>)}
 
       <div className="text-center">
@@ -45,7 +46,7 @@ function Page() {
       <div className="text-center">
         <h1 className="text-4xl font-bold">Updates: ? </h1>
         <p className="text-lg mt-4">
-          List of latest updates 
+          List of latest updates
         </p>
       </div>
     </>


### PR DESCRIPTION
Importing typechecking from __generated__/pageAboutQuery.graphql.ts

Adding type to the about demo before project wide implementation

Should discard null nodes or data and instead return empty array to work with .map.