### PR TITLE
fix: return conflict for rejected match results

### DIFF
--- a/aiarena/api/arenaclient/common/exceptions.py
+++ b/aiarena/api/arenaclient/common/exceptions.py
@@ -11,3 +11,8 @@ class NoGameForClient(APIException):
     status_code = 200
     default_detail = "No game available for client."
     default_code = "no_game_available"
+
+
+class ResultSubmissionConflict(APIException):
+    status_code = 409
+    default_code = "result_submission_conflict"

--- a/aiarena/api/arenaclient/common/result_submission_handler.py
+++ b/aiarena/api/arenaclient/common/result_submission_handler.py
@@ -7,7 +7,6 @@ from django.db import transaction
 from django.db.models import F, Prefetch, Sum
 
 from constance import config
-from rest_framework.exceptions import APIException
 
 from aiarena.core.models import (
     BotCrashLimitAlert,
@@ -21,6 +20,7 @@ from aiarena.core.models import (
 from aiarena.core.services import bot_statistics, bots, competitions
 from aiarena.core.utils import parse_tags
 
+from .exceptions import ResultSubmissionConflict
 from .serializers import (
     SubmitResultBotSerializer,
     SubmitResultParticipationSerializer,
@@ -121,7 +121,7 @@ def submit_result(result_submission: ResultSubmission):
             f"A result was submitted for match {result_submission.match.id}, "
             f"which Bot {result_submission.p1_instance.bot.name} isn't currently in!"
         )
-        raise APIException(
+        raise ResultSubmissionConflict(
             f"Unable to log result: Bot {result_submission.p1_instance.bot.name} is not currently in this match!"
         )
     if not result_submission.p2_instance.bot.is_in_match(result_submission.match.id):
@@ -129,7 +129,7 @@ def submit_result(result_submission: ResultSubmission):
             f"A result was submitted for match {result_submission.match.id}, "
             f"which Bot {result_submission.p2_instance.bot.name} isn't currently in!"
         )
-        raise APIException(
+        raise ResultSubmissionConflict(
             f"Unable to log result: Bot {result_submission.p2_instance.bot.name} is not currently in this match!"
         )
     bot1 = None

--- a/aiarena/api/arenaclient/tests/test_exceptions.py
+++ b/aiarena/api/arenaclient/tests/test_exceptions.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+from aiarena.api.arenaclient.common.exceptions import ResultSubmissionConflict
+from aiarena.api.arenaclient.common.result_submission_handler import ResultSubmission, submit_result
+
+
+def test_result_submission_conflict_returns_http_409() -> None:
+    bot = SimpleNamespace(name="finished-bot", is_in_match=lambda match_id: False)
+    submission = cast(
+        ResultSubmission,
+        SimpleNamespace(
+            match=SimpleNamespace(id=42),
+            p1_instance=SimpleNamespace(bot=bot),
+        ),
+    )
+
+    with pytest.raises(ResultSubmissionConflict) as exc_info:
+        submit_result(submission)
+
+    response = cast(Response, exception_handler(exc_info.value, {}))
+    assert response.status_code == 409
+    assert response.data["detail"] == "Unable to log result: Bot finished-bot is not currently in this match!"

--- a/aiarena/api/arenaclient/tests/test_results.py
+++ b/aiarena/api/arenaclient/tests/test_results.py
@@ -111,7 +111,7 @@ class ResultsTestCase(LoggedInMixin, TransactionTestCase):
         not_started_match = Match.objects.filter(started__isnull=True, result__isnull=True).first()
 
         # should fail
-        response = self._post_to_results(not_started_match.id, "Player1Win", expected_code=500)
+        response = self._post_to_results(not_started_match.id, "Player1Win", expected_code=409)
         self.assertTrue("detail" in response.data)
         self.assertEqual("Unable to log result: Bot bot1 is not currently in this match!", response.data["detail"])
 


### PR DESCRIPTION
Closes #1103

Repeated result submissions currently raise a generic 500 when the match no longer accepts either bot, causing arena clients to retry indefinitely after a successful submission response is lost. Return 409 Conflict for this terminal condition while preserving the existing error detail.

Tested with the focused result-submission exception regression and Ruff; the existing endpoint regression now expects 409.
